### PR TITLE
Add aarch64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,16 @@ IF(ARCH STREQUAL x86_64)
   SET(CLOCK amd64)
 ENDIF(ARCH STREQUAL x86_64)
 
+IF(ARCH STREQUAL aarch64)
+  SET(VALID_ARCH YES)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
+  ADD_DEFINITIONS(-D_GNU_SOURCE)
+  SET(CLOCK aarch64)
+ENDIF(ARCH STREQUAL aarch64)
+
 IF(NOT VALID_ARCH)
   MESSAGE(FATAL_ERROR "ARCH not valid!\n"
-    "Please set ARCH to be one of (i386 | bgl | bgp | x86_64 | ppc64 | ppc64le)")
+    "Please set ARCH to be one of (i386 | bgl | bgp | x86_64 | ppc64 | ppc64le | aarch64)")
 ENDIF(NOT VALID_ARCH)
 
 # ROSS Core code

--- a/core/clock/aarch64.c
+++ b/core/clock/aarch64.c
@@ -1,0 +1,39 @@
+#include <ross.h>
+  
+#ifndef __GNUC__
+#  error gcc asm extensions required
+#endif
+#if ! (defined(__aarch64__))
+#  error only aarch64 platform supported
+#endif
+
+/*
+ * Does same stuff as the amd64, but uses  cntvct_el0
+ */
+static const tw_optdef clock_opts [] =
+{
+        TWOPT_GROUP("ROSS Timing"),
+        TWOPT_ULONGLONG("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
+        TWOPT_END()
+};
+
+const tw_optdef *tw_clock_setup(void)
+{
+        return clock_opts;
+}
+
+
+
+void
+tw_clock_init(tw_pe * me)
+{
+        me->clock_time = 0;
+        me->clock_offset = tw_clock_read();
+}
+
+tw_clock
+tw_clock_now(tw_pe * me)
+{
+        me->clock_time = tw_clock_read() - me->clock_offset;
+        return me->clock_time;
+}

--- a/core/clock/aarch64.h
+++ b/core/clock/aarch64.h
@@ -7,7 +7,7 @@ static inline tw_clock  tw_clock_read(void)
 {
         tw_clock result=0;
 #ifdef ROSS_timing
-       asm volatile ("isb;mrs %0, cntvct_el0" : "=r" (result));
+       asm volatile ("mrs %0, cntvct_el0" : "=r" (result));
 #endif
         return result;
 }

--- a/core/clock/aarch64.h
+++ b/core/clock/aarch64.h
@@ -1,0 +1,15 @@
+#ifndef INC_clock_aarch64
+#define INC_clock_aarch64
+
+typedef uint64_t tw_clock;
+
+static inline tw_clock  tw_clock_read(void)
+{
+        tw_clock result=0;
+#ifdef ROSS_timing
+       asm volatile ("isb;mrs %0, cntvct_el0" : "=r" (result));
+#endif
+        return result;
+}
+
+#endif

--- a/core/ross.h
+++ b/core/ross.h
@@ -182,6 +182,9 @@ typedef uint64_t tw_lpid;
 #ifdef ROSS_CLOCK_bgq
 #  include "clock/bgq.h"
 #endif
+#ifdef ROSS_CLOCK_aarch64
+#  include "clock/aarch64.h"
+#endif
 
 #ifdef ROSS_NETWORK_mpi
 #  include "network-mpi.h"


### PR DESCRIPTION
Add aarch64 to the allowed architectures, add core/clock accordingly. I've just mirrored amd64 — format doesn't appear to be consistent across other architectures.

```
100% tests passed, 0 tests failed out of 39

Total Test time (real) = 442.00 sec
```

Happy to adjust anything to make this more project compliant...

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [Contributing guide](https://github.com/carothersc/ROSS/blob/gh-pages/CONTRIBUTING.md) in the gh-pages branch).
  Include a link to your blog post in the Pull Request.
- [ ] Builds should cleanly compile with -Wall and -Wextra. 
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
