### PR TITLE
travis for building docs to ross-org.github.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,9 @@ after_success:
   - git config --global user.email ${GIT_EMAIL}
   -
   - # clone the whole repo again, but switch to gh_pages branch
-  - git clone -b gh-pages --single-branch https://github.com/carothersc/ROSS
-  -
-  - cd ROSS
-  - git clone -b master --single-branch https://github.com/carothersc/ROSS
+  - git clone -b master --single-branch https://github.com/ross-org/ross-org.github.io
+  - cd ross-org.github.io
+  - git clone -b master --single-branch https://github.com/ross-org/ROSS
   - cd ROSS
   - mkdir build && cd build
   - ARCH=x86_64 cmake -DROSS_BUILD_DOXYGEN=ON -DDOXYGEN_CALLER_GRAPHS=ON -DDOXYGEN_CALL_GRAPHS=ON ..
@@ -72,4 +71,4 @@ after_success:
   - mv ROSS/build/docs/html ROSS-docs/docs
   - git add ROSS-docs
   - git commit -m "Automatic doxygen build."
-  - git push https://${GH_TOKEN}@github.com/carothersc/ROSS gh-pages
+  - git push https://${GH_TOKEN}@github.com/ROSS-org/ross-org.github.io master

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You may find the now-deprecated version at the [ROSS-Legacy tag](https://github.
 Using this repository you can compare files from the new `ROSS/core` to `ROSS/ross`.
 For a detailed list of changes between old ROSS and SR please visit [the wiki](https://github.com/ROSS-org/ROSS/wiki/Differences-between-Simplified-ROSS-and-ROSS-Legacy).
 
-[![Build Status](https://travis-ci.org/ROSS-org/ROSS.svg?branch=master)](https://travis-ci.org/ROSS-org/ROSS)
+[![Build Status](https://travis-ci.com/ROSS-org/ROSS.svg?branch=master)](https://travis-ci.org/ROSS-org/ROSS)
 [![codecov.io](http://codecov.io/github/ROSS-org/ROSS/coverage.svg?branch=master)](http://codecov.io/github/ROSS-org/ROSS?branch=master)
 [![Doxygen](https://img.shields.io/badge/doxygen-reference-blue.svg)](http://ross-org.github.io/ROSS-docs/docs/html)
 
@@ -50,7 +50,7 @@ Developed as Simplified ROSS ([gonsie/SR](http://github.com/gonsie/SR)), this ve
   - [ROSS-Models](http://github.com/ROSS-org/ROSS-Models) is a set of existing models
   - [template-model](http://github.com/ROSS-org/template-model) is a starting place for new models
   - [RIO](http://github.com/ROSS-org/RIO) is a work-in-progress checkpointing framework
-  
+
 
 3. *Optional* Symlink your model to ROSS.
 Please [this wiki page](https://github.com/ROSS-org/ROSS/wiki/Constructing-the-Model) for details about creating and integrating a model with ROSS.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Welcome to a leaner, meaner, *faster* version of ROSS.
 While the entire history of ROSS has been preserved in this repository, a major change in the directory structure has made getting the full history of a file somewhat of a pain.
-You may find the now-deprecated version at the [ROSS-Legacy tag](https://github.com/carothersc/ROSS/releases/tag/Legacy) in this repository.
+You may find the now-deprecated version at the [ROSS-Legacy tag](https://github.com/ROSS-org/ROSS/releases/tag/Legacy) in this repository.
 Using this repository you can compare files from the new `ROSS/core` to `ROSS/ross`.
-For a detailed list of changes between old ROSS and SR please visit [the wiki](https://github.com/carothersc/ROSS/wiki/Differences-between-Simplified-ROSS-and-ROSS-Legacy).
+For a detailed list of changes between old ROSS and SR please visit [the wiki](https://github.com/ROSS-org/ROSS/wiki/Differences-between-Simplified-ROSS-and-ROSS-Legacy).
 
-[![Build Status](https://travis-ci.org/carothersc/ROSS.svg?branch=master)](https://travis-ci.org/carothersc/ROSS)
-[![codecov.io](http://codecov.io/github/carothersc/ROSS/coverage.svg?branch=master)](http://codecov.io/github/carothersc/ROSS?branch=master)
-[![Doxygen](https://img.shields.io/badge/doxygen-reference-blue.svg)](http://carothersc.github.io/ROSS/ROSS-docs/docs/html)
+[![Build Status](https://travis-ci.org/ROSS-org/ROSS.svg?branch=master)](https://travis-ci.org/ROSS-org/ROSS)
+[![codecov.io](http://codecov.io/github/ROSS-org/ROSS/coverage.svg?branch=master)](http://codecov.io/github/ROSS-org/ROSS?branch=master)
+[![Doxygen](https://img.shields.io/badge/doxygen-reference-blue.svg)](http://ross-org.github.io/ROSS-docs/docs/html)
 
 ## History
 
@@ -35,7 +35,7 @@ Developed as Simplified ROSS ([gonsie/SR](http://github.com/gonsie/SR)), this ve
 
 1. Clone the repository to your local machine:
   ```
-  git clone -b master --single-branch git@github.com:carothersc/ROSS.git
+  git clone -b master --single-branch git@github.com:ROSS-org/ROSS.git
   cd ROSS
   ```
   Since the ROSS repostiory is quite large, it is recommended that you only clone the master branch.
@@ -47,19 +47,19 @@ Developed as Simplified ROSS ([gonsie/SR](http://github.com/gonsie/SR)), this ve
   git submodule update
   ```
   Currently, ROSS includes three submodules:
-  - [ROSS-Models](http://github.com/carothersc/ROSS-Models) is a set of existing models
-  - [template-model](http://github.com/nmcglohon/template-model) is a starting place for new models
-  - [RIO](http://github.com/gonsie/RIO) is a work-in-progress checkpointing framework
+  - [ROSS-Models](http://github.com/ROSS-org/ROSS-Models) is a set of existing models
+  - [template-model](http://github.com/ROSS-org/template-model) is a starting place for new models
+  - [RIO](http://github.com/ROSS-org/RIO) is a work-in-progress checkpointing framework
   
 
 3. *Optional* Symlink your model to ROSS.
-Please [this wiki page](https://github.com/carothersc/ROSS/wiki/Constructing-the-Model) for details about creating and integrating a model with ROSS.
+Please [this wiki page](https://github.com/ROSS-org/ROSS/wiki/Constructing-the-Model) for details about creating and integrating a model with ROSS.
   ```
   ln -s ~/path-to/your-existing-model models/your-model-name
   ```
 
 3. Create a build directory.
-ROSS developers typically do out-of-tree builds.  See the [Installation page](https://github.com/carothersc/ROSS/wiki/Installation) for more details.
+ROSS developers typically do out-of-tree builds.  See the [Installation page](https://github.com/ROSS-org/ROSS/wiki/Installation) for more details.
   ```
   cd ~/directory-of-builds/
   mkdir ROSS-build
@@ -77,7 +77,7 @@ ROSS developers typically do out-of-tree builds.  See the [Installation page](ht
   ```
 
 5. Run your model.
-See [this wiki page](https://github.com/carothersc/ROSS/wiki/Running-the-Simulator) for details about the ROSS command line options.
+See [this wiki page](https://github.com/ROSS-org/ROSS/wiki/Running-the-Simulator) for details about the ROSS command line options.
   ```
   cd ~/directory-of-builds/ROSS-build/models/your-model
   ./your-model --synch=1               // sequential mode


### PR DESCRIPTION
Maybe this will work on the first commit! Travis should automatically push the update doxygen to the Ross-org.github.io repo.

