### PR TITLE
get time of day clock as default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,9 +109,10 @@ IF(VALID_ARCH)
   MESSAGE(STATUS "Using C_FLAGS: ${CMAKE_C_FLAGS}")
   MESSAGE(STATUS "Using CLOCK: ${CLOCK}")
 ELSE(VALID_ARCH)
-  MESSAGE(FATAL_ERROR "System architecture not recognized!\n"
+  MESSAGE(WARNING "System architecture not recognized!\n"
     "Found: ${CMAKE_SYSTEM_PROCESSOR}\n"
-    "Expected: i386 | x86_64 | ppc64 | ppc64le | aarch64")
+    "Falling back to get-time-of-day clock implementation.")
+  SET(CLOCK gtod)
 ENDIF(VALID_ARCH)
 
 ## MPI

--- a/core/clock/gtod.c
+++ b/core/clock/gtod.c
@@ -1,0 +1,53 @@
+#include <ross.h>
+
+extern unsigned long long g_tw_clock_rate;
+
+static const tw_optdef clock_opts [] =
+{
+ TWOPT_GROUP("ROSS Timing"),
+ TWOPT_ULONGLONG("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
+ TWOPT_END()
+};
+
+const tw_optdef *tw_clock_setup(void)
+{
+	return clock_opts;
+}
+
+tw_clock tw_clock_read(void)
+{
+#ifdef ZERO_BASED
+  static volatile int inited = 0;
+  static volatile tw_clock base = 0;
+#else
+  const tw_clock base = 0;
+#endif
+
+  const tw_clock scale = 1000000;
+  struct timeval tv;
+  gettimeofday(&tv,NULL);
+
+#ifdef ZERO_BASED
+  if(inited == 0) {
+    base = ((tw_clock) tv.tv_sec)*scale + (tw_clock) tv.tv_usec;
+    inited = 1;
+  }
+#endif
+
+  return
+    (((tw_clock) tv.tv_sec)*scale + (tw_clock) tv.tv_usec) - base;
+}
+
+void
+tw_clock_init(tw_pe * me)
+{
+	me->clock_time = 0;
+	me->clock_offset = tw_clock_read();
+}
+
+tw_clock
+tw_clock_now(tw_pe * me)
+{
+	me->clock_time = tw_clock_read() - me->clock_offset;
+	return me->clock_time;
+}

--- a/core/clock/gtod.h
+++ b/core/clock/gtod.h
@@ -1,0 +1,6 @@
+#ifndef INC_clock_gtod
+#define INC_clock_gtod
+
+typedef uint64_t tw_clock;
+
+#endif

--- a/core/ross.h
+++ b/core/ross.h
@@ -185,6 +185,9 @@ typedef uint64_t tw_lpid;
 #ifdef ROSS_CLOCK_aarch64
 #  include "clock/aarch64.h"
 #endif
+#ifdef ROSS_CLOCK_gtod
+#  include "clock/gtod.h"
+#endif
 
 #ifdef ROSS_NETWORK_mpi
 #  include "network-mpi.h"


### PR DESCRIPTION
Added a clock implementation based on `gettimeofday` system call. CMake will fall back to this clock implementation if the system architecture is not recognized.

There should be no impact to existing users and no blog post necessary.