### PR TITLE
Removing ROSS_MEMORY option from the build

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -99,13 +99,6 @@ IF(AVL_TREE)
   SET(ross_srcs ${ross_srcs} avl_tree.h avl_tree.c)
 ENDIF(AVL_TREE)
 
-# ROSS_MEMORY is either on or off depending on whether or not we desire
-# memory buffers.  If it's not set to YES, it defaults to NO
-OPTION(ROSS_MEMORY "ROSS Memory Buffers (membufs)" OFF)
-IF(ROSS_MEMORY)
-  SET(ross_srcs ${ross_srcs} tw-memory.c tw-memoryq.h tw-memory.h)
-ENDIF(ROSS_MEMORY)
-
 # RIO: Restart IO
 OPTION(USE_RIO "Enable RIO checkpointing library?" OFF)
 IF(USE_RIO)


### PR DESCRIPTION
Small fix to build to remove ROSS_MEMORY from Cmake files.  Forgot to do it with the last release. 

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [website Contributing guide](https://github.com/ROSS-org/ross-org.github.io/blob/master/CONTRIBUTING.md)).
  Include a link to your blog post in the Pull Request.
- [ ] Builds should cleanly compile with -Wall and -Wextra.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
