### PR TITLE
tw_opt_set

### DIFF
--- a/core/tw-opts.c
+++ b/core/tw-opts.c
@@ -121,7 +121,7 @@ show_help(void)
 			cnt++;
 		}
 	}
-        
+
         // CMake used to pass options by command line flags
 	fprintf(stderr, "ROSS CMake Configuration Options:\n");
         fprintf(stderr, "  (See build-dir/core/config.h)\n");
@@ -130,7 +130,7 @@ show_help(void)
 void tw_opt_settings(FILE *outfile) {
     const tw_optdef **group = all_groups;
     unsigned cnt = 0;
-    
+
     for (; *group; group++){
         const tw_optdef *def = *group;
         for (; def->type; def++){
@@ -213,7 +213,7 @@ tw_opt_print(void)
 		const tw_optdef *def = *group;
 		for (; def->type; def++)
 		{
-			if (def->type == TWOPTTYPE_GROUP || 
+			if (def->type == TWOPTTYPE_GROUP ||
 				(def->name && 0 == strcmp(def->name, "help")))
 				continue;
 

--- a/core/tw-opts.c
+++ b/core/tw-opts.c
@@ -10,6 +10,11 @@ static int is_empty(const tw_optdef *def);
 static const tw_optdef *opt_groups[10];
 static unsigned int opt_index = 0;
 
+// internally set options registered with tw_opt_set
+#define I_ARGV_MAX 16
+static int    i_argc = 0;
+static char * i_argv[I_ARGV_MAX];
+
 void
 tw_opt_add(const tw_optdef *options)
 {
@@ -415,6 +420,12 @@ tw_opt_parse(int *argc_p, char ***argv_p)
 	all_groups[i++] = basic;
 	all_groups[i] = NULL;
 
+        while (i_argc > 0) {
+            i_argc--;
+            const char *s = i_argv[i_argc];
+            match_opt(s);
+        }
+
 	while (argc > 1)
 	{
 		const char *s = argv[1];
@@ -435,4 +446,24 @@ tw_opt_parse(int *argc_p, char ***argv_p)
 
 	*argc_p = argc;
 	*argv_p = argv;
+}
+
+/**
+ * construct internal arguments to look like command line arguments
+ * these cannot be processed until ross is fully set up and tw_opt_parse is called (from tw_init)
+ */
+void tw_opt_set(const char *opt, const char *value) {
+    if (i_argc >= I_ARGV_MAX) {
+        tw_error(TW_LOC, "Too many internal options, increase I_ARGV_MAX.");
+    }
+
+    unsigned long len = strlen(opt) + strlen(value) + 4;
+    char * s = (char *)malloc(len*sizeof(char));
+    strcpy(s, "--");
+    strcat(s, opt);
+    strcat(s, "=");
+    strcat(s, value);
+
+    i_argv[i_argc] = s;
+    i_argc++;
 }

--- a/core/tw-opts.h
+++ b/core/tw-opts.h
@@ -36,6 +36,8 @@ struct tw_optdef
 extern void tw_opt_parse(int *argc, char ***argv);
 /** Add an opt group */
 extern void tw_opt_add(const tw_optdef *options);
+/** Set an option at runtime. Command line take precedence */
+extern void tw_opt_set(const char *option, const char *value);
 /** Pretty-print the option descriptions (for --help) */
 extern void tw_opt_print(void);
 /** Pretty-print the option descriptions and current values */


### PR DESCRIPTION
This is a new API function which can be used to set options during runtime (any options that are registered with TWOPT). It may be useful for models that always require certain options.

This is also a step in the direction of formalizing the ROSS API and removing the need for models to muck with global variables. The hope is that models only worry about options documented by --help text and never need to remember g_tw_xxx variables.

Some larger discussion should take place in #162.

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [website Contributing guide](https://github.com/ROSS-org/ross-org.github.io/blob/master/CONTRIBUTING.md)).
  Include a link to your blog post in the Pull Request.
- [ ] Builds should cleanly compile with -Wall and -Wextra.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
