### PR TITLE
New tw_stime: bits

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -113,6 +113,13 @@ if (USE_DAMARIS)
     SET(ross_srcs ${ross_srcs} ${ROSS_Damaris_SOURCE_DIR}/core/damaris.h)
 ENDIF(USE_DAMARIS)
 
+OPTION(USE_TW_STIME_BITS "Use bits implementation of tw_stime" OFF)
+IF(USE_TW_STIME_BITS)
+  SET(ross_srcs ${ross_srcs} time/bits.h time/bits.c)
+  INCLUDE_DIRECTORIES(time)
+ENDIF(USE_TW_STIME_BITS)
+
+
 # Use debugging-friendly memory allocation
 OPTION(ROSS_ALLOC_DEBUG "Use naive allocator to be more friendly to memory debugging tools" OFF)
 

--- a/core/config.h.in
+++ b/core/config.h.in
@@ -17,3 +17,4 @@
 #cmakedefine ROSS_ALLOC_DEBUG
 #cmakedefine USE_RIO
 #cmakedefine USE_DAMARIS
+#cmakedefine USE_TW_STIME_BITS

--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -107,8 +107,9 @@ tw_gvt_step2(tw_pe *me)
 	tw_stime pq_min = TW_STIME_MAX;
 	tw_stime net_min = TW_STIME_MAX;
 
-	tw_stime lvt;
-	tw_stime gvt;
+
+        tw_stime lvt;
+        tw_stime gvt;
 
     tw_clock net_start;
 	tw_clock start = tw_clock_read();
@@ -148,14 +149,26 @@ tw_gvt_step2(tw_pe *me)
 
 	all_reduce_cnt++;
 
+        // Note for TW_STIME API
+        // lvt is cast to double when going into the allreduce
+        // thus, the gvt that comes out is a double
+        // and needs to be cast back to an tw_stime object
+        //
+        // must continue to use MPI_DOUBLE type... or reimplement allreduce
+
+        double lvtd = TW_STIME_DBL(lvt);
+        double gvtd;
+
 	if(MPI_Allreduce(
-			&lvt,
-			&gvt,
+			&lvtd,
+			&gvtd,
 			1,
-			MPI_TYPE_TW_STIME,
+			MPI_DOUBLE,
 			MPI_MIN,
 			MPI_COMM_ROSS) != MPI_SUCCESS)
 			tw_error(TW_LOC, "MPI_Allreduce for GVT failed");
+
+        gvt = TW_STIME_CRT(gvtd);
 
 	if(TW_STIME_CMP(gvt, me->GVT_prev) < 0)
 	{

--- a/core/ross.h
+++ b/core/ross.h
@@ -147,6 +147,9 @@ extern "C" {
 typedef unsigned long tw_peid;
 
 /* tw_stime -- Simulation time value for sim clock (NOT wall!) */
+#ifdef USE_TW_STIME_BITS
+#include "time/bits.h"
+#else
 typedef double tw_stime;
 #define MPI_TYPE_TW_STIME   MPI_DOUBLE
 #define TW_STIME_CRT(x)     (x)
@@ -154,6 +157,7 @@ typedef double tw_stime;
 #define TW_STIME_CMP(x, y)  (((x) < (y)) ? -1 : ((x) > (y)))
 #define TW_STIME_ADD(x, y)  ((x) + (y))
 #define TW_STIME_MAX        DBL_MAX
+#endif
 
 /* tw_lpid -- Logical Process "LP" id */
 //typedef unsigned long long tw_lpid;

--- a/core/time/bits.c
+++ b/core/time/bits.c
@@ -1,0 +1,56 @@
+#include "ross.h"
+
+MPI_Datatype MPI_TYPE_TW_STIME;
+
+int tw_stime_cmp(tw_stime x, tw_stime y) {
+    if(x.t < y.t) return -1;
+    if(x.t > y.t) return  1;
+    for(int i = 0; i < TW_STIME_BITS_SIZE; i++) {
+        if(x.bits[i] < y.bits[i]) return -1;
+        if(x.bits[i] > y.bits[i]) return  1;
+    }
+    return 0;
+}
+
+tw_stime tw_stime_add(tw_stime x, tw_stime y) {
+    tw_stime rv;
+    rv.t = x.t + y.t;
+    for (int i = 0; i < TW_STIME_BITS_SIZE; i++) {
+        rv.bits[i] = x.bits[i] + y.bits[i];
+    }
+    return rv;
+}
+
+tw_stime tw_stime_max(void) {
+    tw_stime rv;
+    rv.t = DBL_MAX;
+    return rv;
+}
+
+tw_stime tw_stime_create(double x){
+    tw_stime rv;
+    rv.t = x;
+    for (int i = 0; i < TW_STIME_BITS_SIZE; i++) {
+        rv.bits[i] = 0;
+    }
+    return rv;
+}
+
+void tw_stime_mpi_datatype(void) {
+    int structlen = 2;
+
+    int blocklens[structlen];
+    MPI_Datatype types[structlen];
+    MPI_Aint displacements[structlen];
+
+    blocklens[0] = 1;
+    types[0] = MPI_DOUBLE;
+    displacements[0] = 0;
+
+    blocklens[1] = TW_STIME_BITS_SIZE;
+    types[1] = MPI_LONG_LONG_INT;
+    displacements[1] = sizeof(double);
+
+    MPI_Type_create_struct(structlen, blocklens, displacements, types, &MPI_TYPE_TW_STIME);
+    MPI_Type_commit(&MPI_TYPE_TW_STIME);
+}

--- a/core/time/bits.c
+++ b/core/time/bits.c
@@ -3,9 +3,10 @@
 MPI_Datatype MPI_TYPE_TW_STIME;
 
 int tw_stime_bits_cmp(tw_stime x, tw_stime y) {
+    int i;
     if(x.t < y.t) return -1;
     if(x.t > y.t) return  1;
-    for(int i = 0; i < TW_STIME_BITS_SIZE; i++) {
+    for(i = 0; i < TW_STIME_BITS_SIZE; i++) {
         if(x.bits[i] < y.bits[i]) return -1;
         if(x.bits[i] > y.bits[i]) return  1;
     }
@@ -13,9 +14,10 @@ int tw_stime_bits_cmp(tw_stime x, tw_stime y) {
 }
 
 tw_stime tw_stime_bits_add(tw_stime x, tw_stime y) {
+    int i;
     tw_stime rv;
     rv.t = x.t + y.t;
-    for (int i = 0; i < TW_STIME_BITS_SIZE; i++) {
+    for (i = 0; i < TW_STIME_BITS_SIZE; i++) {
         rv.bits[i] = x.bits[i] + y.bits[i];
     }
     return rv;
@@ -28,9 +30,10 @@ tw_stime tw_stime_bits_max(void) {
 }
 
 tw_stime tw_stime_bits_create(double x){
+    int i;
     tw_stime rv;
     rv.t = x;
-    for (int i = 0; i < TW_STIME_BITS_SIZE; i++) {
+    for (i = 0; i < TW_STIME_BITS_SIZE; i++) {
         rv.bits[i] = 0;
     }
     return rv;

--- a/core/time/bits.c
+++ b/core/time/bits.c
@@ -2,7 +2,7 @@
 
 MPI_Datatype MPI_TYPE_TW_STIME;
 
-int tw_stime_cmp(tw_stime x, tw_stime y) {
+int tw_stime_bits_cmp(tw_stime x, tw_stime y) {
     if(x.t < y.t) return -1;
     if(x.t > y.t) return  1;
     for(int i = 0; i < TW_STIME_BITS_SIZE; i++) {
@@ -12,7 +12,7 @@ int tw_stime_cmp(tw_stime x, tw_stime y) {
     return 0;
 }
 
-tw_stime tw_stime_add(tw_stime x, tw_stime y) {
+tw_stime tw_stime_bits_add(tw_stime x, tw_stime y) {
     tw_stime rv;
     rv.t = x.t + y.t;
     for (int i = 0; i < TW_STIME_BITS_SIZE; i++) {
@@ -21,13 +21,13 @@ tw_stime tw_stime_add(tw_stime x, tw_stime y) {
     return rv;
 }
 
-tw_stime tw_stime_max(void) {
+tw_stime tw_stime_bits_max(void) {
     tw_stime rv;
     rv.t = DBL_MAX;
     return rv;
 }
 
-tw_stime tw_stime_create(double x){
+tw_stime tw_stime_bits_create(double x){
     tw_stime rv;
     rv.t = x;
     for (int i = 0; i < TW_STIME_BITS_SIZE; i++) {
@@ -36,7 +36,7 @@ tw_stime tw_stime_create(double x){
     return rv;
 }
 
-void tw_stime_mpi_datatype(void) {
+void tw_stime_bits_mpi_datatype(void) {
     int structlen = 2;
 
     int blocklens[structlen];

--- a/core/time/bits.h
+++ b/core/time/bits.h
@@ -1,0 +1,25 @@
+#ifndef INC_time_bits_h
+#define INC_time_bits_h
+
+#define TW_STIME_BITS_SIZE 2
+
+typedef struct tw_stime {
+    double t;
+    long long int bits[TW_STIME_BITS_SIZE];
+} tw_stime;
+
+extern MPI_Datatype MPI_TYPE_TW_STIME;
+void tw_stime_mpi_datatype(void);
+
+int tw_stime_cmp(tw_stime x, tw_stime y);
+tw_stime tw_stime_add(tw_stime x, tw_stime y);
+tw_stime tw_stime_max(void);
+tw_stime tw_stime_create(double x);
+
+#define TW_STIME_CRT(x)     (tw_stime_create(x))
+#define TW_STIME_DBL(x)     (x.t)
+#define TW_STIME_CMP(x, y)  (tw_stime_cmp((x), (y)))
+#define TW_STIME_ADD(x, y)  (tw_stime_add((x), (y)))
+#define TW_STIME_MAX        (tw_stime_max())
+
+#endif

--- a/core/time/bits.h
+++ b/core/time/bits.h
@@ -9,17 +9,17 @@ typedef struct tw_stime {
 } tw_stime;
 
 extern MPI_Datatype MPI_TYPE_TW_STIME;
-void tw_stime_mpi_datatype(void);
+void tw_stime_bits_mpi_datatype(void);
 
-int tw_stime_cmp(tw_stime x, tw_stime y);
-tw_stime tw_stime_add(tw_stime x, tw_stime y);
-tw_stime tw_stime_max(void);
-tw_stime tw_stime_create(double x);
+int tw_stime_bits_cmp(tw_stime x, tw_stime y);
+tw_stime tw_stime_bits_add(tw_stime x, tw_stime y);
+tw_stime tw_stime_bits_max(void);
+tw_stime tw_stime_bits_create(double x);
 
-#define TW_STIME_CRT(x)     (tw_stime_create(x))
+#define TW_STIME_CRT(x)     (tw_stime_bits_create(x))
 #define TW_STIME_DBL(x)     (x.t)
-#define TW_STIME_CMP(x, y)  (tw_stime_cmp((x), (y)))
-#define TW_STIME_ADD(x, y)  (tw_stime_add((x), (y)))
-#define TW_STIME_MAX        (tw_stime_max())
+#define TW_STIME_CMP(x, y)  (tw_stime_bits_cmp((x), (y)))
+#define TW_STIME_ADD(x, y)  (tw_stime_bits_add((x), (y)))
+#define TW_STIME_MAX        (tw_stime_bits_max())
 
 #endif

--- a/core/tw-opts.c
+++ b/core/tw-opts.c
@@ -58,9 +58,11 @@ show_help(void)
 				pos += fprintf(stderr, "=dbl");
                                 break;
 
+#ifndef USE_TW_STIME_BITS
 			case TWOPTTYPE_STIME:
 				pos += fprintf(stderr, "=ts");
 				break;
+#endif
 
 			case TWOPTTYPE_CHAR:
 				pos += fprintf(stderr, "=str");
@@ -104,9 +106,11 @@ show_help(void)
 					fprintf(stderr, " (default %.2f)", *((double*)def->value));
                                         break;
 
+#ifndef USE_TW_STIME_BITS
 				case TWOPTTYPE_STIME:
-					fprintf(stderr, " (default %.2f)", *((tw_stime*)def->value));
+                                    fprintf(stderr, " (default %.2f)", *(TW_STIME_DBL((tw_stime*)def->value)));
 					break;
+#endif
 
 				case TWOPTTYPE_CHAR:
 					fprintf(stderr, " (default %s)", (char *) def->value);
@@ -184,9 +188,11 @@ void tw_opt_settings(FILE *outfile) {
                     fprintf(outfile, "%.2f", *((double*)def->value));
                     break;
 
+#ifndef USE_TW_STIME_BITS
                 case TWOPTTYPE_STIME:
-                    fprintf(outfile, "%.2f", *((tw_stime*)def->value));
+                    fprintf(outfile, "%.2f", *(TW_STIME_DBL((tw_stime*)def->value)));
                     break;
+#endif
 
                 case TWOPTTYPE_CHAR:
                     fprintf(outfile, "%s", (char *) def->value);
@@ -249,9 +255,11 @@ tw_opt_print(void)
 					fprintf(f, "%.2f,", *((double*)def->value));
                                         break;
 
+#ifndef USE_TW_STIME_BITS
 				case TWOPTTYPE_STIME:
-					fprintf(f, "%.2f,", *((tw_stime*)def->value));
+                                        fprintf(f, "%.2f,", *(TW_STIME_DBL((tw_stime*)def->value)));
 					break;
+#endif
 
 				case TWOPTTYPE_CHAR:
 					fprintf(f, "%s,", (char *)def->value);
@@ -332,6 +340,7 @@ apply_opt(const tw_optdef *def, const char *value)
 		break;
 	}
 
+#ifndef USE_TW_STIME_BITS
 	case TWOPTTYPE_STIME:
 	{
 		tw_stime v;
@@ -347,6 +356,7 @@ apply_opt(const tw_optdef *def, const char *value)
 		*((tw_stime*)def->value) = v;
 		break;
 	}
+#endif
 
 	case TWOPTTYPE_CHAR:
 	{

--- a/core/tw-opts.c
+++ b/core/tw-opts.c
@@ -108,7 +108,7 @@ show_help(void)
 
 #ifndef USE_TW_STIME_BITS
 				case TWOPTTYPE_STIME:
-                                    fprintf(stderr, " (default %.2f)", *(TW_STIME_DBL((tw_stime*)def->value)));
+                                    fprintf(stderr, " (default %.2f)", *((tw_stime*)def->value));
 					break;
 #endif
 
@@ -190,7 +190,7 @@ void tw_opt_settings(FILE *outfile) {
 
 #ifndef USE_TW_STIME_BITS
                 case TWOPTTYPE_STIME:
-                    fprintf(outfile, "%.2f", *(TW_STIME_DBL((tw_stime*)def->value)));
+                    fprintf(outfile, "%.2f", *((tw_stime*)def->value));
                     break;
 #endif
 
@@ -257,7 +257,7 @@ tw_opt_print(void)
 
 #ifndef USE_TW_STIME_BITS
 				case TWOPTTYPE_STIME:
-                                        fprintf(f, "%.2f,", *(TW_STIME_DBL((tw_stime*)def->value)));
+                                        fprintf(f, "%.2f,", *((tw_stime*)def->value));
 					break;
 #endif
 

--- a/core/tw-opts.h
+++ b/core/tw-opts.h
@@ -7,7 +7,9 @@ enum tw_opttype
 	TWOPTTYPE_ULONG,       /**< value must be an "unsigned long*"      */
 	TWOPTTYPE_ULONGLONG,   /**< value must be an "unsigned long long*" */
 	TWOPTTYPE_UINT,        /**< value must be an "unsigned int*"       */
+#ifndef USE_TW_STIME_BITS
 	TWOPTTYPE_STIME,       /**< value must be a  "tw_stime*"           */
+#endif
         TWOPTTYPE_DOUBLE,      /**< value must be a  "double *"            */
 	TWOPTTYPE_CHAR,        /**< value must be a  "char *"              */
         TWOPTTYPE_FLAG,        /**< value must be an "unsigned int*"       */
@@ -28,7 +30,9 @@ struct tw_optdef
 #define TWOPT_ULONG(n,v,h)     { TWOPTTYPE_ULONG,     (n), (h), &(v) }
 #define TWOPT_ULONGLONG(n,v,h) { TWOPTTYPE_ULONGLONG, (n), (h), &(v) }
 #define TWOPT_UINT(n,v,h)      { TWOPTTYPE_UINT,      (n), (h), &(v) }
-#define TWOPT_STIME(n,v,h)     { TWOPTTYPE_STIME,     (n), (h), &(v) }
+#ifndef USE_TW_STIME_BITS
+  #define TWOPT_STIME(n,v,h)     { TWOPTTYPE_STIME,     (n), (h), &(v) }
+#endif
 #define TWOPT_DOUBLE(n,v,h)    { TWOPTTYPE_DOUBLE,    (n), (h), &(v) }
 #define TWOPT_CHAR(n,v,h)      { TWOPTTYPE_CHAR,      (n), (h), &(v) }
 #define TWOPT_FLAG(n,v,h)      { TWOPTTYPE_FLAG,      (n), (h), &(v) }

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -519,6 +519,10 @@ void tw_scheduler_conservative(tw_pe * me) {
         printf("*** START PARALLEL CONSERVATIVE SIMULATION ***\n\n");
     }
 
+    #ifdef USE_TW_STIME_BITS
+    tw_stime_mpi_datatype();
+    #endif
+
     tw_wall_now(&me->start_time);
     me->stats.s_total = tw_clock_read();
 

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -519,10 +519,6 @@ void tw_scheduler_conservative(tw_pe * me) {
         printf("*** START PARALLEL CONSERVATIVE SIMULATION ***\n\n");
     }
 
-    #ifdef USE_TW_STIME_BITS
-    tw_stime_mpi_datatype();
-    #endif
-
     tw_wall_now(&me->start_time);
     me->stats.s_total = tw_clock_read();
 


### PR DESCRIPTION
This adds a new implementation of stime, using the TW_STIME API. It adds a bit field to the stime object. Its use is demonstrated in the [ross-matrix-models](https://github.com/llnl/ross-matrix-models). 

I’ll have to figure out a way to test this and increase coverage, maybe using the matrix models?


---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [website Contributing guide](https://github.com/ROSS-org/ross-org.github.io/blob/master/CONTRIBUTING.md)).
  Include a link to your blog post in the Pull Request.
- [ ] Builds should cleanly compile with -Wall and -Wextra.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
