### PR TITLE
External TW_STIME

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -113,6 +113,15 @@ if (USE_DAMARIS)
     SET(ross_srcs ${ross_srcs} ${ROSS_Damaris_SOURCE_DIR}/core/damaris.h)
 ENDIF(USE_DAMARIS)
 
+OPTION(USE_EXTERNAL_STIME "Use model-specific tw_stime implementation" OFF)
+IF(USE_EXTERNAL_STIME)
+  #SET(ross_srcs ${ross_srcs} ${MODEL_STIME_SRC} ${MODEL_STIME_HDR})
+  #GET_FILENAME_COMPONENT(${stime_header_path} ${MODEL_STIME_HDR} DIRECTORY)
+  #INCLUDE_DIRECTORIES(${stime_header_path})
+  SET(ross_srcs ${ross_srcs} ${MODEL_STIME_SRC})
+  INCLUDE_DIRECTORIES(${MODEL_STIME_HDR})
+ENDIF(USE_EXTERNAL_STIME)
+
 # Use debugging-friendly memory allocation
 OPTION(ROSS_ALLOC_DEBUG "Use naive allocator to be more friendly to memory debugging tools" OFF)
 

--- a/core/config.h.in
+++ b/core/config.h.in
@@ -17,3 +17,8 @@
 #cmakedefine ROSS_ALLOC_DEBUG
 #cmakedefine USE_RIO
 #cmakedefine USE_DAMARIS
+
+#cmakedefine USE_EXTERNAL_STIME
+#ifdef USE_EXTERNAL_STIME
+#include "${MODEL_STIME_HDR}"
+#endif

--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -107,8 +107,9 @@ tw_gvt_step2(tw_pe *me)
 	tw_stime pq_min = TW_STIME_MAX;
 	tw_stime net_min = TW_STIME_MAX;
 
-	tw_stime lvt;
-	tw_stime gvt;
+
+        tw_stime lvt;
+        tw_stime gvt;
 
     tw_clock net_start;
 	tw_clock start = tw_clock_read();
@@ -148,14 +149,26 @@ tw_gvt_step2(tw_pe *me)
 
 	all_reduce_cnt++;
 
+        // Note for TW_STIME API
+        // lvt is cast to double when going into the allreduce
+        // thus, the gvt that comes out is a double
+        // and needs to be cast back to an tw_stime object
+        //
+        // must continue to use MPI_DOUBLE type... or reimplement allreduce
+
+        double lvtd = TW_STIME_DBL(lvt);
+        double gvtd;
+
 	if(MPI_Allreduce(
-			&lvt,
-			&gvt,
+			&lvtd,
+			&gvtd,
 			1,
-			MPI_TYPE_TW_STIME,
+			MPI_DOUBLE,
 			MPI_MIN,
 			MPI_COMM_ROSS) != MPI_SUCCESS)
 			tw_error(TW_LOC, "MPI_Allreduce for GVT failed");
+
+        gvt = TW_STIME_CRT(gvtd);
 
 	if(TW_STIME_CMP(gvt, me->GVT_prev) < 0)
 	{

--- a/core/ross.h
+++ b/core/ross.h
@@ -141,12 +141,12 @@ extern "C" {
 #  define free(b) must_not_use_free
 #endif
 
-// #include "config.h" -- moved to individual files that need them -- e.g., tw-setup.c
-
 /* tw_peid -- Processing Element "PE" id */
 typedef unsigned long tw_peid;
 
 /* tw_stime -- Simulation time value for sim clock (NOT wall!) */
+/* Model stime header included by config.h */
+#ifndef USE_EXTERNAL_STIME
 typedef double tw_stime;
 #define MPI_TYPE_TW_STIME   MPI_DOUBLE
 #define TW_STIME_CRT(x)     (x)
@@ -154,6 +154,7 @@ typedef double tw_stime;
 #define TW_STIME_CMP(x, y)  (((x) < (y)) ? -1 : ((x) > (y)))
 #define TW_STIME_ADD(x, y)  ((x) + (y))
 #define TW_STIME_MAX        DBL_MAX
+#endif
 
 /* tw_lpid -- Logical Process "LP" id */
 //typedef unsigned long long tw_lpid;

--- a/core/tw-opts.c
+++ b/core/tw-opts.c
@@ -58,9 +58,11 @@ show_help(void)
 				pos += fprintf(stderr, "=dbl");
                                 break;
 
+#ifndef USE_EXTERNAL_STIME
 			case TWOPTTYPE_STIME:
 				pos += fprintf(stderr, "=ts");
 				break;
+#endif
 
 			case TWOPTTYPE_CHAR:
 				pos += fprintf(stderr, "=str");
@@ -104,9 +106,11 @@ show_help(void)
 					fprintf(stderr, " (default %.2f)", *((double*)def->value));
                                         break;
 
+#ifndef USE_EXTERNAL_STIME
 				case TWOPTTYPE_STIME:
-					fprintf(stderr, " (default %.2f)", *((tw_stime*)def->value));
+                                    fprintf(stderr, " (default %.2f)", *((tw_stime*)def->value));
 					break;
+#endif
 
 				case TWOPTTYPE_CHAR:
 					fprintf(stderr, " (default %s)", (char *) def->value);
@@ -184,9 +188,11 @@ void tw_opt_settings(FILE *outfile) {
                     fprintf(outfile, "%.2f", *((double*)def->value));
                     break;
 
+#ifndef USE_EXTERNAL_STIME
                 case TWOPTTYPE_STIME:
                     fprintf(outfile, "%.2f", *((tw_stime*)def->value));
                     break;
+#endif
 
                 case TWOPTTYPE_CHAR:
                     fprintf(outfile, "%s", (char *) def->value);
@@ -249,9 +255,11 @@ tw_opt_print(void)
 					fprintf(f, "%.2f,", *((double*)def->value));
                                         break;
 
+#ifndef USE_EXTERNAL_STIME
 				case TWOPTTYPE_STIME:
-					fprintf(f, "%.2f,", *((tw_stime*)def->value));
+                                        fprintf(f, "%.2f,", *((tw_stime*)def->value));
 					break;
+#endif
 
 				case TWOPTTYPE_CHAR:
 					fprintf(f, "%s,", (char *)def->value);
@@ -332,6 +340,7 @@ apply_opt(const tw_optdef *def, const char *value)
 		break;
 	}
 
+#ifndef USE_EXTERNAL_STIME
 	case TWOPTTYPE_STIME:
 	{
 		tw_stime v;
@@ -347,6 +356,7 @@ apply_opt(const tw_optdef *def, const char *value)
 		*((tw_stime*)def->value) = v;
 		break;
 	}
+#endif
 
 	case TWOPTTYPE_CHAR:
 	{

--- a/core/tw-opts.h
+++ b/core/tw-opts.h
@@ -7,7 +7,9 @@ enum tw_opttype
 	TWOPTTYPE_ULONG,       /**< value must be an "unsigned long*"      */
 	TWOPTTYPE_ULONGLONG,   /**< value must be an "unsigned long long*" */
 	TWOPTTYPE_UINT,        /**< value must be an "unsigned int*"       */
+#ifndef USE_EXTERNAL_STIME
 	TWOPTTYPE_STIME,       /**< value must be a  "tw_stime*"           */
+#endif
         TWOPTTYPE_DOUBLE,      /**< value must be a  "double *"            */
 	TWOPTTYPE_CHAR,        /**< value must be a  "char *"              */
         TWOPTTYPE_FLAG,        /**< value must be an "unsigned int*"       */
@@ -28,7 +30,9 @@ struct tw_optdef
 #define TWOPT_ULONG(n,v,h)     { TWOPTTYPE_ULONG,     (n), (h), &(v) }
 #define TWOPT_ULONGLONG(n,v,h) { TWOPTTYPE_ULONGLONG, (n), (h), &(v) }
 #define TWOPT_UINT(n,v,h)      { TWOPTTYPE_UINT,      (n), (h), &(v) }
-#define TWOPT_STIME(n,v,h)     { TWOPTTYPE_STIME,     (n), (h), &(v) }
+#ifndef USE_EXTERNAL_STIME
+  #define TWOPT_STIME(n,v,h)     { TWOPTTYPE_STIME,     (n), (h), &(v) }
+#endif
 #define TWOPT_DOUBLE(n,v,h)    { TWOPTTYPE_DOUBLE,    (n), (h), &(v) }
 #define TWOPT_CHAR(n,v,h)      { TWOPTTYPE_CHAR,      (n), (h), &(v) }
 #define TWOPT_FLAG(n,v,h)      { TWOPTTYPE_FLAG,      (n), (h), &(v) }

--- a/core/tw-pe.c
+++ b/core/tw-pe.c
@@ -41,7 +41,7 @@ tw_pe_init(void)
     memset(&no_type, 0, sizeof(no_type));
     tw_pe_settype(&no_type);
 
-    g_tw_pe->trans_msg_ts = DBL_MAX;
+    g_tw_pe->trans_msg_ts = TW_STIME_MAX;
     g_tw_pe->gvt_status = 0;
 
     // TODO is the PE RNG ever actually used?


### PR DESCRIPTION
This PR closes the loop on how the TW_STIME API should be implemented by model developers. It does not make sense for a model-specific tw_stime to be added to ROSS core, particularly if the tw_stime object needs to be developed over time as the model is developed. With this PR, model developers can tell ROSS at configuration time where to find the implementation of tw_stime class, files which may exist outside of the ROSS repo. 

I definitely need to update the TW_STIME API documentation. I’ve run local tests and there should be no impact to models which do not take advantage of this.

This replaces #168.

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [website Contributing guide](https://github.com/ROSS-org/ross-org.github.io/blob/master/CONTRIBUTING.md)).
  Include a link to your blog post in the Pull Request.
