### PR TITLE
New Core ROSS RNG streams; Event Time Signature Paradigm; Deterministic Tiebreaker

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -114,6 +114,9 @@ if (USE_DAMARIS)
     SET(ross_srcs ${ross_srcs} ${ROSS_Damaris_SOURCE_DIR}/core/damaris.h)
 ENDIF(USE_DAMARIS)
 
+# Use deterministic unbiased RNG tiebreaker for event ties
+OPTION(USE_RAND_TIEBREAKER "Build with deterministic unbiased tiebreaker for event ties" ON)
+
 # Use debugging-friendly memory allocation
 OPTION(ROSS_ALLOC_DEBUG "Use naive allocator to be more friendly to memory debugging tools" OFF)
 

--- a/core/avl_tree.c
+++ b/core/avl_tree.c
@@ -46,28 +46,29 @@ avlSearch(AvlTree t, tw_event *key)
     if (TW_STIME_CMP(key->recv_ts, t->key->recv_ts) == 0) {
         // Timestamp is the same
 #ifdef USE_RAND_TIEBREAKER
-        if (key->event_tiebreaker == t->key->event_tiebreaker) {
+            //this is OK to only compare first tiebreaker because the event ID and PE will settle collisions
+            if (key->sig.event_tiebreaker[0] == t->key->sig.event_tiebreaker[0]) {
 #endif
-            if (key->event_id == t->key->event_id) {
-                // Event ID is the same
-                if (key->send_pe == t->key->send_pe) {
-                    // send_pe is the same
-                    return 1;
+                if (key->event_id == t->key->event_id) {
+                    // Event ID is the same
+                    if (key->send_pe == t->key->send_pe) {
+                        // send_pe is the same
+                        return 1;
+                    }
+                    else {
+                        // send_pe is different
+                        return avlSearch(t->child[key->send_pe > t->key->send_pe], key);
+                    }
                 }
                 else {
-                    // send_pe is different
-                    return avlSearch(t->child[key->send_pe > t->key->send_pe], key);
+                    // Event ID is different
+                    return avlSearch(t->child[key->event_id > t->key->event_id], key);
                 }
+#ifdef USE_RAND_TIEBREAKER
             }
             else {
-                // Event ID is different
-                return avlSearch(t->child[key->event_id > t->key->event_id], key);
+                return avlSearch(t->child[key->sig.event_tiebreaker[0] > t->key->sig.event_tiebreaker[0]], key);
             }
-#ifdef USE_RAND_TIEBREAKER
-        }
-        else {
-            return avlSearch(t->child[key->event_tiebreaker > t->key->event_tiebreaker], key);
-        }
 #endif
     }
     else {
@@ -194,31 +195,30 @@ avlInsert(AvlTree *t, tw_event *key)
 
     if (TW_STIME_CMP(key->recv_ts, (*t)->key->recv_ts) == 0) {
 #ifdef USE_RAND_TIEBREAKER
-        // We have a timestamp tie, check the event tiebreaker
-        if (key->event_tiebreaker == (*t)->key->event_tiebreaker) {
-            // we have an event tiebreaker tie, check the event ID (because it's different versions of same event)
+            // We have a timestamp tie, check the event tiebreaker
+            if (key->sig.event_tiebreaker[0] == (*t)->key->sig.event_tiebreaker[0]) {
 #endif
-            if (key->event_id == (*t)->key->event_id) {
-                // We have a event ID tie, check the send_pe
-                if (key->send_pe == (*t)->key->send_pe) {
-                    // This shouldn't happen but we'll allow it
-                    tw_printf(TW_LOC, "The events are identical!!!\n");
+                if (key->event_id == (*t)->key->event_id) {
+                    // We have a event ID tie, check the send_pe
+                    if (key->send_pe == (*t)->key->send_pe) {
+                        // This shouldn't happen but we'll allow it
+                        tw_printf(TW_LOC, "The events are identical!!!\n");
+                    }
+                    avlInsert(&(*t)->child[key->send_pe > (*t)->key->send_pe], key);
+                    avlRebalance(t);
                 }
-                avlInsert(&(*t)->child[key->send_pe > (*t)->key->send_pe], key);
-                avlRebalance(t);
+                else {
+                    // Event IDs are different
+                    avlInsert(&(*t)->child[key->event_id > (*t)->key->event_id], key);
+                    avlRebalance(t);
+                }
+#ifdef USE_RAND_TIEBREAKER
             }
             else {
-                // Event IDs are different
-                avlInsert(&(*t)->child[key->event_id > (*t)->key->event_id], key);
+                // event tiebreakers are different
+                avlInsert(&(*t)->child[key->sig.event_tiebreaker[0] > (*t)->key->sig.event_tiebreaker[0]], key);
                 avlRebalance(t);
             }
-#ifdef USE_RAND_TIEBREAKER
-        }
-        else {
-            // event tiebreakers are different
-            avlInsert(&(*t)->child[key->event_tiebreaker > (*t)->key->event_tiebreaker], key);
-            avlRebalance(t);
-        }
 #endif
     }
     else {
@@ -280,44 +280,43 @@ avlDelete(AvlTree *t, tw_event *key)
 
     if (TW_STIME_CMP(key->recv_ts, (*t)->key->recv_ts) == 0) {
 #ifdef USE_RAND_TIEBREAKER
-        // We have a timestamp tie, check the event tiebreaker
-        if (key->event_tiebreaker == (*t)->key->event_tiebreaker) {
-            //we have an event tiebreaker tie, (same event but different version)
+            if (key->sig.event_tiebreaker[0] == (*t)->key->sig.event_tiebreaker[0]) {
+                //we have an event tiebreaker tie, (same event but different version)
 #endif
-            if (key->event_id == (*t)->key->event_id) {
-                // We have a event ID tie, check the send_pe
-                if (key->send_pe == (*t)->key->send_pe) {
-                    // This is actually the one we want to delete
+                if (key->event_id == (*t)->key->event_id) {
+                    // We have a event ID tie, check the send_pe
+                    if (key->send_pe == (*t)->key->send_pe) {
+                        // This is actually the one we want to delete
 
-                    target = (*t)->key;
-                    /* do we have a right child? */
-                    if ((*t)->child[1] != AVL_EMPTY) {
-                        /* give root min value in right subtree */
-                        (*t)->key = avlDeleteMin(&(*t)->child[1]);
+                        target = (*t)->key;
+                        /* do we have a right child? */
+                        if ((*t)->child[1] != AVL_EMPTY) {
+                            /* give root min value in right subtree */
+                            (*t)->key = avlDeleteMin(&(*t)->child[1]);
+                        }
+                        else {
+                            /* splice out root */
+                            oldroot = (*t);
+                            *t = (*t)->child[0];
+                            avl_free(oldroot);
+                        }
                     }
                     else {
-                        /* splice out root */
-                        oldroot = (*t);
-                        *t = (*t)->child[0];
-                        avl_free(oldroot);
+                        // Timestamp and event IDs are the same, but different send_pe
+                        target = avlDelete(&(*t)->child[key->send_pe > (*t)->key->send_pe], key);
                     }
                 }
                 else {
-                    // Timestamp and event IDs are the same, but different send_pe
-                    target = avlDelete(&(*t)->child[key->send_pe > (*t)->key->send_pe], key);
+                    // Timestamps are the same but event IDs differ
+                    target = avlDelete(&(*t)->child[key->event_id > (*t)->key->event_id], key);
                 }
+#ifdef USE_RAND_TIEBREAKER
             }
             else {
-                // Timestamps are the same but event IDs differ
-                target = avlDelete(&(*t)->child[key->event_id > (*t)->key->event_id], key);
+                // event tiebreakers are different
+                target = avlDelete(&(*t)->child[key->sig.event_tiebreaker[0] > (*t)->key->sig.event_tiebreaker[0]], key);
             }
-#ifdef USE_RAND_TIEBREAKER
-        }
-        else {
-            // event tiebreakers are different
-            target = avlDelete(&(*t)->child[key->event_tiebreaker > (*t)->key->event_tiebreaker], key);
-        }
-    #endif
+#endif
     }
     else {
         // Timestamps are different

--- a/core/config.h.in
+++ b/core/config.h.in
@@ -17,3 +17,4 @@
 #cmakedefine ROSS_ALLOC_DEBUG
 #cmakedefine USE_RIO
 #cmakedefine USE_DAMARIS
+#cmakedefine USE_RAND_TIEBREAKER

--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -160,17 +160,18 @@ tw_gvt_step2(tw_pe *me)
 		lvt_sig = net_min_sig;
 	}
 
+	memset(&gvt_sig, 0, sizeof(tw_event_sig));
+
 	all_reduce_cnt++;
 	if(MPI_Allreduce(
 		&lvt_sig,
 		&gvt_sig,
 		1,
-		MPI_TYPE_TW_STIME,
+	MPI_TYPE_TW_STIME,
 		MPI_MIN,
 		MPI_COMM_ROSS) != MPI_SUCCESS)
 		tw_error(TW_LOC, "MPI_Allreduce for GVT event signatures failed");
 
-	gvt_sig.event_tiebreaker = 0;
 
 	if(tw_event_sig_compare(gvt_sig, me->GVT_prev_sig) < 0)
 	{
@@ -191,8 +192,9 @@ tw_gvt_step2(tw_pe *me)
 
 	if (tw_event_sig_compare(me->GVT_sig, gvt_sig) > 0)
 	{
-		tw_error(TW_LOC, "PE %u GVT decreased %g  %g  -> %g  %g",
-				me->id, me->GVT_sig.recv_ts, me->GVT_sig.event_tiebreaker, gvt_sig.recv_ts, gvt_sig.event_tiebreaker);
+		tw_error(TW_LOC, "PE %u GVT decreased %g -> %g",
+				me->id, me->GVT_sig.recv_ts, gvt_sig.recv_ts);
+
 	}
 
 	if (TW_STIME_DBL(gvt_sig.recv_ts) / g_tw_ts_end > percent_complete && (g_tw_mynode == g_tw_masternode))

--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -69,8 +69,13 @@ tw_gvt_stats(FILE * f)
 void
 tw_gvt_step1(tw_pe *me)
 {
+	// printf("%d\n",g_tw_max_opt_lookahead);
 	if(me->gvt_status == TW_GVT_COMPUTE ||
+#ifdef USE_RAND_TIEBREAKER
+           (++gvt_cnt < g_tw_gvt_interval && (TW_STIME_DBL(tw_pq_minimum_sig(me->pq).recv_ts) - TW_STIME_DBL(me->GVT_sig.recv_ts) < g_tw_max_opt_lookahead)))
+#else
            (++gvt_cnt < g_tw_gvt_interval && (TW_STIME_DBL(tw_pq_minimum(me->pq)) - TW_STIME_DBL(me->GVT) < g_tw_max_opt_lookahead)))
+#endif
 		return;
 
 	me->gvt_status = TW_GVT_COMPUTE;
@@ -83,7 +88,11 @@ tw_gvt_step1_realtime(tw_pe *me)
 
   if( (me->gvt_status == TW_GVT_COMPUTE) ||
       ( ((current_rt = tw_clock_read()) - g_tw_gvt_interval_start_cycles < g_tw_gvt_realtime_interval)
+#ifdef USE_RAND_TIEBREAKER
+          && (TW_STIME_DBL(tw_pq_minimum_sig(me->pq).recv_ts) - TW_STIME_DBL(me->GVT_sig.recv_ts) < g_tw_max_opt_lookahead)))
+#else
           && (TW_STIME_DBL(tw_pq_minimum(me->pq)) - TW_STIME_DBL(me->GVT) < g_tw_max_opt_lookahead)))
+#endif
     {
       /* if( me->id == 0 ) */
       /* 	{ */
@@ -98,7 +107,157 @@ tw_gvt_step1_realtime(tw_pe *me)
   me->gvt_status = TW_GVT_COMPUTE;
 }
 
+#ifdef USE_RAND_TIEBREAKER
+//This function had so many interweavings of USE_RAND_TIEBREAKER that it was simpler to duplicate the function
+void
+tw_gvt_step2(tw_pe *me)
+{
+	long long local_white = 0;
+	long long total_white = 0;
 
+	tw_event_sig pq_min_sig = (tw_event_sig){TW_STIME_MAX, TW_STIME_MAX};
+	tw_event_sig net_min_sig = (tw_event_sig){TW_STIME_MAX, TW_STIME_MAX};
+
+	tw_event_sig lvt_sig;
+	tw_event_sig gvt_sig;
+
+    tw_clock net_start;
+	tw_clock start = tw_clock_read();
+
+	if(me->gvt_status != TW_GVT_COMPUTE)
+		return;
+	while(1)
+	  {
+        net_start = tw_clock_read();
+	    tw_net_read(me);
+        me->stats.s_net_read += tw_clock_read() - net_start;
+
+	    // send message counts to create consistent cut
+	    local_white = me->s_nwhite_sent - me->s_nwhite_recv;
+	    all_reduce_cnt++;
+	    if(MPI_Allreduce(
+			     &local_white,
+			     &total_white,
+			     1,
+			     MPI_LONG_LONG,
+			     MPI_SUM,
+			     MPI_COMM_ROSS) != MPI_SUCCESS)
+	      tw_error(TW_LOC, "MPI_Allreduce for GVT failed");
+
+	    if(total_white == 0)
+	      break;
+	  }
+	pq_min_sig = tw_pq_minimum_sig(me->pq);
+	net_min_sig = tw_net_minimum_sig();
+
+	lvt_sig = me->trans_msg_sig;
+	if(tw_event_sig_compare(lvt_sig, pq_min_sig) > 0)
+	{
+	  lvt_sig = pq_min_sig;
+	}
+	if(tw_event_sig_compare(lvt_sig, net_min_sig) > 0)
+	{
+		lvt_sig = net_min_sig;
+	}
+
+	all_reduce_cnt++;
+	if(MPI_Allreduce(
+		&lvt_sig,
+		&gvt_sig,
+		1,
+		MPI_TYPE_TW_STIME,
+		MPI_MIN,
+		MPI_COMM_ROSS) != MPI_SUCCESS)
+		tw_error(TW_LOC, "MPI_Allreduce for GVT event signatures failed");
+
+	gvt_sig.event_tiebreaker = 0;
+
+	if(tw_event_sig_compare(gvt_sig, me->GVT_prev_sig) < 0)
+	{
+		g_tw_gvt_no_change = 0;
+	} else
+	{
+				gvt_sig = me->GVT_prev_sig;
+		g_tw_gvt_no_change++;
+		if (g_tw_gvt_no_change >= g_tw_gvt_max_no_change) {
+			tw_error(
+				TW_LOC,
+				"GVT computed %d times in a row"
+				" without changing: GVT = %14.14lf, PREV %14.14lf"
+				" -- GLOBAL SYNCH -- out of memory!",
+				g_tw_gvt_no_change, gvt_sig.recv_ts, me->GVT_prev_sig.recv_ts);
+		}
+	}
+
+	if (tw_event_sig_compare(me->GVT_sig, gvt_sig) > 0)
+	{
+		tw_error(TW_LOC, "PE %u GVT decreased %g  %g  -> %g  %g",
+				me->id, me->GVT_sig.recv_ts, me->GVT_sig.event_tiebreaker, gvt_sig.recv_ts, gvt_sig.event_tiebreaker);
+	}
+
+	if (TW_STIME_DBL(gvt_sig.recv_ts) / g_tw_ts_end > percent_complete && (g_tw_mynode == g_tw_masternode))
+	{
+		gvt_print(gvt_sig.recv_ts);
+	}
+
+	me->s_nwhite_sent = 0;
+	me->s_nwhite_recv = 0;
+	me->trans_msg_sig = (tw_event_sig){TW_STIME_MAX, TW_STIME_MAX};
+	me->GVT_prev_sig = (tw_event_sig){TW_STIME_MAX, TW_STIME_MAX};
+	me->GVT_sig = gvt_sig;
+	me->gvt_status = TW_GVT_NORMAL;
+
+	gvt_cnt = 0;
+
+	// update GVT timing stats
+	me->stats.s_gvt += tw_clock_read() - start;
+
+	// only FC if OPTIMISTIC or REALTIME, do not do for DEBUG MODE
+	if( g_tw_synchronization_protocol == OPTIMISTIC ||
+	    g_tw_synchronization_protocol == OPTIMISTIC_REALTIME )
+	  {
+	    start = tw_clock_read();
+	    tw_pe_fossil_collect();
+	    me->stats.s_fossil_collect += tw_clock_read() - start;
+	  }
+
+    // do any necessary instrumentation calls
+    if ((g_st_engine_stats == GVT_STATS || g_st_engine_stats == ALL_STATS) &&
+        g_tw_gvt_done % g_st_num_gvt == 0 && TW_STIME_DBL(gvt_sig.recv_ts) <= g_tw_ts_end)
+    {
+#ifdef USE_DAMARIS
+        if (g_st_damaris_enabled)
+        {
+            st_damaris_expose_data(me, gvt, GVT_COL);
+            st_damaris_end_iteration();
+        }
+        else
+            st_collect_engine_data(me, GVT_COL);
+#else
+		st_collect_engine_data(me, GVT_COL);
+#endif
+    }
+#ifdef USE_DAMARIS
+    // need to make sure damaris_end_iteration is called if GVT instrumentation not turned on
+    //if (!g_st_stats_enabled && g_st_real_time_samp) //need to make sure if one PE enters this, all do; otherwise deadlock
+    if (g_st_damaris_enabled && (g_st_engine_stats == RT_STATS || g_st_engine_stats == VT_STATS))
+    {
+        st_damaris_end_iteration();
+    }
+#endif
+
+    if ((g_st_model_stats == GVT_STATS || g_st_model_stats == ALL_STATS) && g_tw_gvt_done % g_st_num_gvt == 0)
+        st_collect_model_data(me, ((double)tw_clock_read()) / g_tw_clock_rate, GVT_STATS);
+
+    st_inst_dump();
+    // done with instrumentation related stuff
+
+	g_tw_gvt_done++;
+
+	// reset for the next gvt round -- for use in realtime GVT mode only!!
+	g_tw_gvt_interval_start_cycles = tw_clock_read();
+ }
+#else
 void
 tw_gvt_step2(tw_pe *me)
 {
@@ -243,3 +402,4 @@ tw_gvt_step2(tw_pe *me)
 	// reset for the next gvt round -- for use in realtime GVT mode only!!
 	g_tw_gvt_interval_start_cycles = tw_clock_read();
  }
+#endif

--- a/core/instrumentation/st-model-data.c
+++ b/core/instrumentation/st-model-data.c
@@ -55,7 +55,11 @@ void st_collect_model_data(tw_pe *pe, double current_rt, int stats_type)
     sample_md.sample_sz = sizeof(model_md);
     sample_md.real_time = current_rt;
     model_md.peid = (unsigned int) g_tw_mynode;
+#ifdef USE_RAND_TIEBREAKER
+    model_md.gvt = (float) TW_STIME_DBL(pe->GVT_sig.recv_ts);
+#else
     model_md.gvt = (float) TW_STIME_DBL(pe->GVT);
+#endif
     model_md.stats_type = stats_type;
 
     for (lpid = 0; lpid < g_tw_nlp; lpid++)

--- a/core/instrumentation/st-sim-engine.c
+++ b/core/instrumentation/st-sim-engine.c
@@ -18,7 +18,11 @@ void st_collect_engine_data(tw_pe *pe, int col_type)
     tw_get_stats(pe, &s);
 
     sample_metadata sample_md;
+#ifdef USE_RAND_TIEBREAKER
+    sample_md.ts = pe->GVT_sig.recv_ts;
+#else
     sample_md.ts = pe->GVT;
+#endif
     sample_md.real_time = (double)tw_clock_read() / g_tw_clock_rate;
 
     if (g_st_pe_data)
@@ -121,7 +125,11 @@ void st_collect_engine_data_kps(tw_pe *pe, tw_kp *kp, sample_metadata *sample_md
     kp_stats.s_rb_secondary = (unsigned int)(kp->kp_stats->s_rb_secondary - kp->last_stats[col_type]->s_rb_secondary);
     kp_stats.s_nsend_network = (unsigned int)(kp->kp_stats->s_nsend_network - kp->last_stats[col_type]->s_nsend_network);
     kp_stats.s_nread_network = (unsigned int)(kp->kp_stats->s_nread_network - kp->last_stats[col_type]->s_nread_network);
+#ifdef USE_RAND_TIEBREAKER
+    kp_stats.time_ahead_gvt = (float)(TW_STIME_DBL(kp->last_sig.recv_ts) - TW_STIME_DBL(pe->GVT_sig.recv_ts));
+#else
     kp_stats.time_ahead_gvt = (float)(TW_STIME_DBL(kp->last_time) - TW_STIME_DBL(pe->GVT));
+#endif
 
     int net_events = kp_stats.s_nevent_processed - kp_stats.s_e_rbs;
     if (net_events > 0)

--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -163,7 +163,7 @@ tw_net_abort(void)
 
 void
 tw_net_stop(void)
-{
+{ 
 #ifdef USE_DAMARIS
     if (g_st_damaris_enabled)
         st_damaris_ross_finalize();
@@ -215,8 +215,8 @@ tw_net_minimum(void)
 #ifdef USE_RAND_TIEBREAKER
 tw_event_sig
 tw_net_minimum_sig(void)
-{
-    tw_event_sig m = (tw_event_sig){TW_STIME_MAX, TW_STIME_MAX};
+{  
+    tw_event_sig m = tw_get_init_sig(TW_STIME_MAX, TW_STIME_MAX);
     tw_event *e;
     unsigned int i;
 

--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -212,6 +212,31 @@ tw_net_minimum(void)
   return m;
 }
 
+#ifdef USE_RAND_TIEBREAKER
+tw_event_sig
+tw_net_minimum_sig(void)
+{
+    tw_event_sig m = (tw_event_sig){TW_STIME_MAX, TW_STIME_MAX};
+    tw_event *e;
+    unsigned int i;
+
+    e = outq.head;
+    while (e) {
+      if (tw_event_sig_compare(m, e->sig) > 0)
+        m = e->sig;
+      e = e->next;
+    }
+
+    for (i = 0; i < posted_sends.cur; i++) {
+      e = posted_sends.event_list[i];
+      if (tw_event_sig_compare(m, e->sig) > 0)
+        m = e->sig;
+    }
+
+  return m;
+}
+#endif
+
 /**
  * @brief Calls MPI_Testsome on the provided queue, to check for finished operations.
  *
@@ -362,14 +387,22 @@ recv_finish(tw_pe *me, tw_event *e, char * buffer)
   e->caused_by_me = NULL;
   e->cause_next = NULL;
 
+#ifdef USE_RAND_TIEBREAKER
+  if(tw_event_sig_compare(e->sig, me->GVT_sig) < 0)
+    tw_error(TW_LOC, "%d: Received straggler from %d: %lf < GVT%lf (%d)",
+	     me->id,  e->send_pe, e->sig.recv_ts, me->GVT_sig.recv_ts, e->state.cancel_q);
 
-
+  if(tw_gvt_inprogress(me)) {
+      me->trans_msg_sig = (tw_event_sig_compare(me->trans_msg_sig, e->sig) < 0) ? me->trans_msg_sig : e->sig;
+  }
+#else
   if(TW_STIME_CMP(e->recv_ts, me->GVT) < 0)
     tw_error(TW_LOC, "%d: Received straggler from %d: %lf (%d)",
 	     me->id,  e->send_pe, e->recv_ts, e->state.cancel_q);
 
   if(tw_gvt_inprogress(me))
       me->trans_msg_ts = (TW_STIME_CMP(me->trans_msg_ts, e->recv_ts) < 0) ? me->trans_msg_ts : e->recv_ts;
+#endif
 
   // if cancel event, retrieve and flush
   // else, store in hash table
@@ -408,7 +441,11 @@ recv_finish(tw_pe *me, tw_event *e, char * buffer)
    * stateful models that produce incorrect results when presented with
    * duplicate messages with no rollback between them.
    */
+#ifdef USE_RAND_TIEBREAKER
+  if(me == dest_pe && tw_event_sig_compare(e->dest_lp->kp->last_sig, e->sig) <= 0 && !dest_pe->cancel_q) {
+#else
   if(me == dest_pe && TW_STIME_CMP(e->dest_lp->kp->last_time, e->recv_ts) <= 0 && !dest_pe->cancel_q) {
+#endif
     /* Fast case, we are sending to our own PE and
      * there is no rollback caused by this send.
      */

--- a/core/network-mpi.h
+++ b/core/network-mpi.h
@@ -95,6 +95,15 @@ extern void tw_net_barrier(void);
  */
 extern tw_stime tw_net_minimum(void);
 
+#ifdef USE_RAND_TIEBREAKER
+/**
+ * @brief Obtain the event signature for the lowest ordered event inside the network buffers.
+ *
+ * @return minimum event signature for this PE's network buffers
+ */
+extern tw_event_sig tw_net_minimum_sig(void);
+#endif
+
 /**
  * @brief Function to reduce all the statistics for output.
  * @attention Notice that the MPI_Reduce "count" parameter is greater than one.

--- a/core/queue/splay.c
+++ b/core/queue/splay.c
@@ -378,13 +378,13 @@ tw_pq_minimum(splay_tree *pq)
 }
 
 #ifdef USE_RAND_TIEBREAKER
-tw_event_sig
+inline tw_event_sig
 tw_pq_minimum_sig(splay_tree *pq)
 {
 	return ((pq->least ? pq->least->sig : (tw_event_sig){TW_STIME_MAX,TW_STIME_MAX}));
 }
 
-tw_eventid
+inline tw_eventid
 tw_pq_minimum_get_event_id(splay_tree *pq)
 {
 	return((pq->least ? pq->least->event_id : UINT_MAX));

--- a/core/queue/splay.c
+++ b/core/queue/splay.c
@@ -27,6 +27,8 @@
 
 #include <ross.h>
 
+#define ROSS_WARN_TIE_COLLISION 1
+
 #define UP(t)		((t)->up)
 #define UPUP(t)		((t)->up->up)
 #define LEFT(t)		((t)->next)
@@ -117,7 +119,14 @@ static unsigned int tw_pq_compare_less_than_rand(tw_event *n, tw_event *e)
 			else if (n->event_id > e->event_id)
 				return 0;
 			else {
-				tw_error(TW_LOC,"Identical events found - impossible\n");
+				if (ROSS_WARN_TIE_COLLISION)
+					printf("ROSS Splay Tree Warning: Identical Tiebreaker and Event IDs found - Implies RNG Collision\n");
+				if(n->send_pe < e->send_pe)
+					return 1;
+				else if (n->send_pe > e->send_pe)
+					return 0;
+				else
+					tw_error(TW_LOC,"Identical events found - impossible\n");
 			}
 		}
         else if (e->sig.tie_lineage_length > n->sig.tie_lineage_length) //give priority to one with shorter lineage

--- a/core/queue/splay.c
+++ b/core/queue/splay.c
@@ -102,20 +102,28 @@ static unsigned int tw_pq_compare_less_than_rand(tw_event *n, tw_event *e)
 		return 0;
     else
     {
-			if (n->event_tiebreaker < e->event_tiebreaker)
+        int min_len = min_int(e->sig.tie_lineage_length, n->sig.tie_lineage_length);
+        for(int i = 0; i < min_len; i++)
+        {
+            if (e->sig.event_tiebreaker[i] < n->sig.event_tiebreaker[i])
+                return 0;
+            else if (e->sig.event_tiebreaker[i] > n->sig.event_tiebreaker[i])
+                return 1;
+        }
+        if (e->sig.tie_lineage_length == n->sig.tie_lineage_length) //total tie
+		{
+			if (n->event_id < e->event_id)
 				return 1;
-			else if (n->event_tiebreaker > e->event_tiebreaker)
+			else if (n->event_id > e->event_id)
 				return 0;
 			else {
-				if (n->event_id < e->event_id)
-					return 1;
-				else if (n->event_id > e->event_id)
-					return 0;
-				else {
-					tw_error(TW_LOC,"Identical events found - impossible\n");
-				}
+				tw_error(TW_LOC,"Identical events found - impossible\n");
 			}
-		// }
+		}
+        else if (e->sig.tie_lineage_length > n->sig.tie_lineage_length) //give priority to one with shorter lineage
+            return 1;
+        else
+            return 0;
     }
 }
 #endif

--- a/core/queue/tw-queue.h
+++ b/core/queue/tw-queue.h
@@ -7,6 +7,9 @@ tw_pq *tw_pq_create(void);
 void tw_pq_enqueue(tw_pq *, tw_event *);
 tw_event *tw_pq_dequeue(tw_pq *);
 tw_stime tw_pq_minimum(tw_pq *);
+#ifdef USE_RAND_TIEBREAKER
+tw_event_sig tw_pq_minimum_sig(tw_pq *);
+#endif
 void tw_pq_delete_any(tw_pq *, tw_event *);
 unsigned int tw_pq_get_size(tw_pq *);
 unsigned int tw_pq_max_size(tw_pq *);

--- a/core/rand-clcg4.c
+++ b/core/rand-clcg4.c
@@ -366,6 +366,7 @@ rng_init(int v, int w)
 	
 	if(g_tw_rng_seed)
 	{
+        printf("Clamping Provided Seeds\n");
         clamp_seed((uint32_t*)g_tw_rng_seed);
 		for(j = 0; j < 4; j++)
 			rng->seed[j] = g_tw_rng_seed[j];

--- a/core/rand-clcg4.c
+++ b/core/rand-clcg4.c
@@ -331,7 +331,7 @@ tw_rand_init_streams(tw_lp * lp, unsigned int nstreams, unsigned int n_core_stre
   lp->rng = (tw_rng_stream *) tw_calloc(TW_LOC, "LP RNG Streams", sizeof(*lp->rng), nstreams);
   lp->core_rng = (tw_rng_stream *) tw_calloc(TW_LOC, "LP Core RNG Streams", sizeof(*lp->core_rng), n_core_streams);
 
-  unsigned int total_num_noncore_rngs = g_tw_nRNG_per_lp * (g_tw_nlp * tw_nnodes());
+  unsigned int total_num_noncore_rngs = g_tw_nRNG_per_lp * g_tw_total_lps;
 
   for(i = 0; i < nstreams; i++) {
             tw_rand_initial_seed(&lp->rng[i], (lp->gid * g_tw_nRNG_per_lp) + i);

--- a/core/rand-clcg4.h
+++ b/core/rand-clcg4.h
@@ -46,9 +46,10 @@ struct tw_rng_stream
 };
 
 extern tw_rng	*rng_init(int v, int w);
+extern tw_rng   *rng_core_init(int v, int w);
 extern void     rng_set_initial_seed();
-extern void     rng_init_generator(tw_rng_stream * g, SeedType Where);
-extern void     rng_set_seed(tw_rng_stream * g, uint32_t * s);
+extern void     rng_init_generator(tw_rng_stream * g, SeedType Where, tw_rng * the_rng);
+extern void     rng_set_seed(tw_rng_stream * g, uint32_t * s, tw_rng * the_rng);
 extern void     rng_get_state(tw_rng_stream * g, uint32_t * s);
 extern void     rng_write_state(tw_rng_stream * g, FILE *f);
 extern double   rng_gen_val(tw_rng_stream * g);

--- a/core/ross-extern.h
+++ b/core/ross-extern.h
@@ -1,7 +1,7 @@
 #ifndef INC_ross_extern_h
 #define INC_ross_extern_h
 
-extern void tw_rand_init_streams(tw_lp * lp, unsigned int nstreams);
+extern void tw_rand_init_streams(tw_lp * lp, unsigned int nstreams, unsigned int n_core_streams);
 
 /*
  * tw-stats.c
@@ -23,6 +23,7 @@ extern tw_lp **g_tw_lp;
 extern tw_kp **g_tw_kp;
 extern int      g_tw_fossil_attempts;
 extern unsigned int g_tw_nRNG_per_lp;
+extern unsigned int g_tw_nRNG_core_per_lp; //Separate ROSS engine-only use RNG streams
 extern tw_lpid g_tw_rng_default;
 extern tw_seed g_tw_rng_seed;
 extern unsigned int g_tw_mblock;

--- a/core/ross-extern.h
+++ b/core/ross-extern.h
@@ -17,6 +17,7 @@ extern map_local_f g_tw_custom_lp_global_to_local_map;
 extern map_custom_f g_tw_custom_initial_mapping;
 extern tw_lp_map g_tw_mapping;
 extern tw_lpid  g_tw_nlp;
+extern tw_lpid  g_tw_total_lps; //Total LPs in the simulation
 extern tw_lpid g_tw_lp_offset;
 extern tw_kpid  g_tw_nkp;
 extern tw_lp **g_tw_lp;

--- a/core/ross-extern.h
+++ b/core/ross-extern.h
@@ -27,6 +27,7 @@ extern unsigned int g_tw_nRNG_per_lp;
 extern unsigned int g_tw_nRNG_core_per_lp; //Separate ROSS engine-only use RNG streams
 extern tw_lpid g_tw_rng_default;
 extern tw_seed g_tw_rng_seed;
+extern tw_seed g_tw_core_rng_seed;
 extern unsigned int g_tw_mblock;
 extern unsigned int g_tw_gvt_interval;
 extern unsigned long long g_tw_max_opt_lookahead;

--- a/core/ross-extern.h
+++ b/core/ross-extern.h
@@ -85,6 +85,9 @@ extern unsigned long long g_tw_clock_rate;
  */
 extern void tw_event_send(tw_event * event);
 extern void tw_event_rollback(tw_event * event);
+#ifdef USE_RAND_TIEBREAKER
+extern int tw_event_sig_compare(tw_event_sig e_sig, tw_event_sig n_sig);
+#endif
 
 /*
  * ross-inline.h
@@ -117,6 +120,9 @@ extern void     tw_kp_put_back_output_buffer(tw_out *out);
 
 extern void tw_kp_rollback_event(tw_event *event);
 extern void tw_kp_rollback_to(tw_kp * kp, tw_stime to);
+#ifdef USE_RAND_TIEBREAKER
+extern void tw_kp_rollback_to_sig(tw_kp * kp, tw_event_sig to_sig);
+#endif
 
 /*
  * tw-pe.c

--- a/core/ross-global.c
+++ b/core/ross-global.c
@@ -22,6 +22,7 @@ map_custom_f g_tw_custom_initial_mapping=NULL;
 tw_lp_map    g_tw_mapping=LINEAR;
 
 tw_lpid         g_tw_nlp = 0;
+tw_lpid         g_tw_total_lps = 0; //Total LPs in the simulation
 tw_lpid		g_tw_lp_offset = 0;
 tw_kpid         g_tw_nkp = 1;
 tw_lp		**g_tw_lp = NULL;

--- a/core/ross-global.c
+++ b/core/ross-global.c
@@ -13,6 +13,7 @@
 	 * g_tw_kp          -- Public KP object array (on this processor)
 	 * g_tw_fossil_attempts  -- Number of times fossil_collect is called
          * g_tw_nRNG_per_lp -- Number of RNG per LP
+	 * g_tw_nRNG_core_per_lp -- Number of ROSS core RNG per LP for use by ROSS engine exclusively
 	 */
 
 tw_synch     g_tw_synchronization_protocol=NO_SYNCH;
@@ -27,6 +28,7 @@ tw_lp		**g_tw_lp = NULL;
 tw_kp		**g_tw_kp = NULL;
 int             g_tw_fossil_attempts = 0;
 unsigned int    g_tw_nRNG_per_lp = 1;
+unsigned int    g_tw_nRNG_core_per_lp = 1;
 tw_lpid         g_tw_rng_default = 1;
 tw_seed        g_tw_rng_seed = NULL;
 unsigned int	g_tw_sim_started = 0;

--- a/core/ross-global.c
+++ b/core/ross-global.c
@@ -32,6 +32,7 @@ unsigned int    g_tw_nRNG_per_lp = 1;
 unsigned int    g_tw_nRNG_core_per_lp = 1;
 tw_lpid         g_tw_rng_default = 1;
 tw_seed        g_tw_rng_seed = NULL;
+tw_seed        g_tw_core_rng_seed = NULL;
 unsigned int	g_tw_sim_started = 0;
 size_t g_tw_msg_sz;
 size_t g_tw_delta_sz = 0;

--- a/core/ross-inline.h
+++ b/core/ross-inline.h
@@ -81,12 +81,18 @@ tw_event_new(tw_lpid dest_gid, tw_stime offset_ts, tw_lp * sender)
     }
   }
 
+  e->send_pe = sender->pe->id;
   e->dest_lp = (tw_lp *) dest_gid;
   e->dest_lpid = dest_gid;
   e->src_lp = sender;
   e->recv_ts = recv_ts;
   e->send_ts = tw_now(sender);
   e->critical_path = sender->critical_path + 1;
+
+#ifdef USE_RAND_TIEBREAKER
+  e->event_tiebreaker = tw_rand_unif(sender->core_rng); //create a random number used to deterministically break event ties, this is rolled back in tw_event_rollback() during the sender LP cancel loop
+  e->sig = (tw_event_sig){e->recv_ts, e->event_tiebreaker};
+#endif
 
   tw_free_output_messages(e, 0);
 

--- a/core/ross-inline.h
+++ b/core/ross-inline.h
@@ -90,8 +90,20 @@ tw_event_new(tw_lpid dest_gid, tw_stime offset_ts, tw_lp * sender)
   e->critical_path = sender->critical_path + 1;
 
 #ifdef USE_RAND_TIEBREAKER
-  e->event_tiebreaker = tw_rand_unif(sender->core_rng); //create a random number used to deterministically break event ties, this is rolled back in tw_event_rollback() during the sender LP cancel loop
-  e->sig = (tw_event_sig){e->recv_ts, e->event_tiebreaker};
+tw_event *now_event = sender->kp->pe->cur_event;
+tw_stime u_rand_val = tw_rand_unif(sender->core_rng); //create a random number used to deterministically break event ties, this is rolled back in tw_event_rollback() during the sender LP cancel loop
+e->sig.recv_ts = recv_ts;
+if (offset_ts == 0) {
+  if (now_event->sig.tie_lineage_length > MAX_TIE_CHAIN)
+    tw_error(TW_LOC, "Maximum zero-offset tie chain reached (%d), increase #define in ross-types.h",MAX_TIE_CHAIN);
+  memcpy(e->sig.event_tiebreaker, now_event->sig.event_tiebreaker, sizeof(tw_stime)*(now_event->sig.tie_lineage_length));
+  e->sig.event_tiebreaker[now_event->sig.tie_lineage_length] = u_rand_val;
+  e->sig.tie_lineage_length = now_event->sig.tie_lineage_length + 1;
+}
+else {
+  e->sig.event_tiebreaker[0] = u_rand_val;
+  e->sig.tie_lineage_length = 1;
+}
 #endif
 
   tw_free_output_messages(e, 0);

--- a/core/ross-kernel-inline.h
+++ b/core/ross-kernel-inline.h
@@ -76,10 +76,24 @@ static inline void *
   return lp->cur_state;
 }
 
+#ifdef USE_RAND_TIEBREAKER
+static inline tw_stime
+     tw_now(tw_lp const * lp)
+{
+  return (lp->kp->last_sig.recv_ts);
+}
+
+static inline tw_event_sig
+     tw_now_sig(tw_lp const *lp)
+{
+  return (lp->kp->last_sig);
+}
+#else
 static inline tw_stime
      tw_now(tw_lp const * lp)
 {
   return (lp->kp->last_time);
 }
+#endif
 
 #endif

--- a/core/ross-random.c
+++ b/core/ross-random.c
@@ -10,6 +10,15 @@ tw_rand_init(uint32_t v, uint32_t w)
 }
 
 /*
+ * tw_rand_core_init
+ */
+tw_rng	*
+tw_rand_core_init(uint32_t v, uint32_t w)
+{
+    return rng_core_init(v, w);
+}
+
+/*
  * tw_rand_integer
  *
  * For LP # gen, return a uniform rn from low to high 

--- a/core/ross-random.h
+++ b/core/ross-random.h
@@ -12,7 +12,8 @@ typedef struct tw_rng_stream tw_rng_stream;
  * Public Function Prototypes
  */
 extern tw_rng	*tw_rand_init(uint32_t v, uint32_t w);
-extern void	tw_rand_initial_seed(tw_rng_stream * g, tw_lpid id);
+extern tw_rng   *tw_rand_core_init(uint32_t v, uint32_t w);
+extern void	    tw_rand_initial_seed(tw_rng_stream * g, tw_lpid id, tw_rng * the_rng);
 extern long     tw_rand_integer(tw_rng_stream * g, long low, long high);
 extern unsigned long tw_rand_ulong(tw_rng_stream * g, unsigned long low, unsigned long high);
 extern long     tw_rand_binomial(tw_rng_stream * g, long N, double P);

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -315,6 +315,7 @@ struct tw_lp {
     void *cur_state; /**< @brief Current application LP data */
     tw_lptype  *type; /**< @brief Type of this LP, including service callbacks */
     tw_rng_stream *rng; /**< @brief  RNG stream array for this LP */
+    tw_rng_stream *core_rng; /**< @brief RNG stream array for ROSS non-model operation - possible alternative to a model_rng pointer array*/
 
     unsigned int critical_path; /**< @brief Critical path value for this LP */
 

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -484,6 +484,7 @@ struct tw_pe {
 #endif
 
     tw_rng  *rng; /**< @brief Pointer to the random number generator on this PE */
+    tw_rng  *core_rng; /**< @brief Pointer to the core random number generator on this PE */
 };
 
 #ifdef USE_RAND_TIEBREAKER

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -240,6 +240,13 @@ typedef struct tw_out {
     char message[256 - 2*sizeof(void *)];
 } tw_out;
 
+#ifdef USE_RAND_TIEBREAKER
+typedef struct tw_event_sig {
+    tw_stime recv_ts;
+    tw_stime event_tiebreaker;
+} tw_event_sig;
+#endif
+
 /**
  * tw_event:
  * @brief Event Stucture
@@ -262,6 +269,11 @@ struct tw_event {
     tw_event *cause_next;           /**< @brief Next in parent's caused_by_me chain */
 
     tw_eventid   event_id;          /**< @brief Unique id assigned by src_lp->pe if remote. */
+
+#ifdef USE_RAND_TIEBREAKER
+    tw_stime     event_tiebreaker;  /**< @brief Random value used to deterministically resolve event ties */
+    tw_event_sig sig;
+#endif
 
     /** Status of the event's queue location(s). */
     struct {
@@ -326,7 +338,11 @@ struct tw_lp {
 
     /* tw_suspend variables */
     tw_event    *suspend_event;
+#ifdef USE_RAND_TIEBREAKER
+    tw_event_sig suspend_sig;
+#else
     tw_stime     suspend_time;
+#endif
     unsigned int suspend_error_number;
     unsigned int suspend_do_orig_event_rc;
     unsigned int suspend_flag;
@@ -358,7 +374,11 @@ struct tw_kp {
 #endif
 
     tw_eventq pevent_q; /**< @brief Events processed by LPs bound to this KP */
+#ifdef USE_RAND_TIEBREAKER
+    tw_event_sig last_sig; /**< @brief Event signature of the current event being processed */
+#else
     tw_stime last_time; /**< @brief Time of the current event being processed */
+#endif
     tw_stat s_nevent_processed; /**< @brief Number of events processed */
 
     long s_e_rbs; /**< @brief Number of events rolled back by this LP */
@@ -401,10 +421,17 @@ struct tw_pe {
     unsigned char cev_abort; /**< @brief Current event being processed must be aborted */
     unsigned char gvt_status; /**< @brief Bits available for gvt computation */
 
+#ifdef USE_RAND_TIEBREAKER
+    tw_event_sig trans_msg_sig; /**< @brief Last transient messages' time signature */
+    tw_event_sig GVT_sig; /**< @brief Global Virtual Time Signature */
+    tw_event_sig GVT_prev_sig;
+    tw_event_sig LVT_sig; /**< @brief Local (to PE) Virtual Time Signature */
+#else
     tw_stime trans_msg_ts; /**< @brief Last transient messages' time stamp */
     tw_stime GVT; /**< @brief Global Virtual Time */
     tw_stime GVT_prev;
     tw_stime LVT; /**< @brief Local (to PE) Virtual Time */
+#endif
 
 #ifdef ROSS_GVT_mpi_allreduce
     long long s_nwhite_sent;

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -245,6 +245,28 @@ typedef struct tw_event_sig {
     tw_stime recv_ts;
     tw_stime event_tiebreaker;
 } tw_event_sig;
+
+//compares the 'new' event to the signature. If the new event is to occur
+//n_sig later (larger) than e_sig signature, return -1
+//n_sig before (smaller) than e_sig signature, return 1
+//at the signature - return 0
+static inline int tw_event_sig_compare(tw_event_sig e_sig, tw_event_sig n_sig)
+{
+    int time_compare = TW_STIME_CMP(e_sig.recv_ts, n_sig.recv_ts);
+    if (time_compare != 0)
+        return time_compare;
+    else
+    {
+        if (e_sig.event_tiebreaker < n_sig.event_tiebreaker)
+            return -1;
+        else if (e_sig.event_tiebreaker > n_sig.event_tiebreaker)
+            return 1;
+        else {
+                // tw_error(TW_LOC,"Identical events (matching tiebreaker) found\n");
+                return 0;
+        }
+    }
+}
 #endif
 
 /**

--- a/core/tw-event.c
+++ b/core/tw-event.c
@@ -6,6 +6,30 @@ static inline void link_causality (tw_event *nev, tw_event *cev) {
     cev->caused_by_me = nev;
 }
 
+#ifdef USE_RAND_TIEBREAKER
+//compares the 'new' event to the signature. If the new event is to occur
+//n_sig later (larger) than e_sig signature, return -1
+//n_sig before (smaller) than e_sig signature, return 1
+//at the signature - return 0
+inline int tw_event_sig_compare(tw_event_sig e_sig, tw_event_sig n_sig)
+{
+    int time_compare = TW_STIME_CMP(e_sig.recv_ts, n_sig.recv_ts);
+    if (time_compare != 0)
+        return time_compare;
+    else
+    {
+        if (e_sig.event_tiebreaker < n_sig.event_tiebreaker)
+            return -1;
+        else if (e_sig.event_tiebreaker > n_sig.event_tiebreaker)
+            return 1;
+        else {
+                // tw_error(TW_LOC,"Identical events (matching tiebreaker) found\n");
+                return 0;
+        }
+    }
+}
+#endif
+
 void tw_event_send(tw_event * event) {
     tw_lp     *src_lp = event->src_lp;
     tw_pe     *send_pe = src_lp->pe;
@@ -58,7 +82,11 @@ void tw_event_send(tw_event * event) {
         event->dest_lp = tw_getlocal_lp((tw_lpid) event->dest_lp);
         dest_pe = event->dest_lp->pe;
 
+#ifdef USE_RAND_TIEBREAKER
+        if (send_pe == dest_pe && tw_event_sig_compare(event->dest_lp->kp->last_sig, event->sig) <= 0) {
+#else
         if (send_pe == dest_pe && TW_STIME_CMP(event->dest_lp->kp->last_time, recv_ts) <= 0) {
+#endif
             /* Fast case, we are sending to our own PE and there is
             * no rollback caused by this send.  We cannot have any
             * transient messages on local sends so we can return.
@@ -93,7 +121,11 @@ void tw_event_send(tw_event * event) {
     }
 
     if(tw_gvt_inprogress(send_pe)) {
+#ifdef USE_RAND_TIEBREAKER
+        send_pe->trans_msg_sig = (tw_event_sig_compare(send_pe->trans_msg_sig, event->sig) < 0) ? send_pe->trans_msg_sig : event->sig;
+#else
         send_pe->trans_msg_ts = (TW_STIME_CMP(send_pe->trans_msg_ts, recv_ts) < 0) ? send_pe->trans_msg_ts : recv_ts;
+#endif
     }
 }
 
@@ -123,7 +155,11 @@ static inline void event_cancel(tw_event * event) {
         //event->src_lp->lp_stats->s_nsend_net_remote--;
 
         if(tw_gvt_inprogress(send_pe)) {
+#ifdef USE_RAND_TIEBREAKER
+            send_pe->trans_msg_sig = (tw_event_sig_compare(send_pe->trans_msg_sig, event->sig) < 0) ? send_pe->trans_msg_sig : event->sig;
+#else
             send_pe->trans_msg_ts = (TW_STIME_CMP(send_pe->trans_msg_ts, event->recv_ts) < 0) ? send_pe->trans_msg_ts : event->recv_ts;
+#endif
         }
 
         return;
@@ -156,7 +192,11 @@ static inline void event_cancel(tw_event * event) {
                 local_cancel(send_pe, event);
 
                 if(tw_gvt_inprogress(send_pe)) {
+#ifdef USE_RAND_TIEBREAKER
+                    send_pe->trans_msg_sig = (tw_event_sig_compare(send_pe->trans_msg_sig, event->sig) < 0) ? send_pe->trans_msg_sig : event->sig;
+#else
                     send_pe->trans_msg_ts = (TW_STIME_CMP(send_pe->trans_msg_ts, event->recv_ts) < 0) ? send_pe->trans_msg_ts : event->recv_ts;
+#endif
                 }
                 break;
 
@@ -171,7 +211,11 @@ static inline void event_cancel(tw_event * event) {
         send_pe->stats.s_nsend_loc_remote--;
 
         if(tw_gvt_inprogress(send_pe)) {
+#ifdef USE_RAND_TIEBREAKER
+            send_pe->trans_msg_sig = (tw_event_sig_compare(send_pe->trans_msg_sig, event->sig) < 0) ? send_pe->trans_msg_sig : event->sig;
+#else
             send_pe->trans_msg_ts = (TW_STIME_CMP(send_pe->trans_msg_ts, event->recv_ts) < 0) ? send_pe->trans_msg_ts : event->recv_ts;
+#endif
         }
     } else {
         tw_error(TW_LOC, "Should be remote cancel!");
@@ -185,17 +229,29 @@ void tw_event_rollback(tw_event * event) {
     tw_free_output_messages(event, 0);
 
     dest_lp->pe->cur_event = event;
+#ifdef USE_RAND_TIEBREAKER
+    dest_lp->kp->last_sig = event->sig;
+#else
     dest_lp->kp->last_time = event->recv_ts;
+#endif
 
     if( dest_lp->suspend_flag &&
 	dest_lp->suspend_event == event &&
 	// Must test time stamp since events are reused once GVT sweeps by
+#ifdef USE_RAND_TIEBREAKER
+    tw_event_sig_compare(dest_lp->suspend_sig, event->sig) == 0)
+#else
 	TW_STIME_CMP(dest_lp->suspend_time, event->recv_ts) == 0)
+#endif
       {
 	// unsuspend the LP
 	dest_lp->suspend_flag = 0;
 	dest_lp->suspend_event = NULL;
+#ifdef USE_RAND_TIEBREAKER
+    dest_lp->suspend_sig = (tw_event_sig){0,0};
+#else
 	dest_lp->suspend_time = TW_STIME_CRT(0.0);
+#endif
 	dest_lp->suspend_error_number = 0;
 
 	if( dest_lp->suspend_do_orig_event_rc == 0 )
@@ -229,7 +285,9 @@ jump_over_rc_event_handler:
     while (e) {
         tw_event *n = e->cause_next;
         e->cause_next = NULL;
-
+#ifdef USE_RAND_TIEBREAKER
+        tw_rand_reverse_unif(e->src_lp->core_rng); //undo the tiebreaker rng advanced by this LP for the subsequent event
+#endif
         event_cancel(e);
         e = n;
     }

--- a/core/tw-event.c
+++ b/core/tw-event.c
@@ -6,30 +6,6 @@ static inline void link_causality (tw_event *nev, tw_event *cev) {
     cev->caused_by_me = nev;
 }
 
-#ifdef USE_RAND_TIEBREAKER
-//compares the 'new' event to the signature. If the new event is to occur
-//n_sig later (larger) than e_sig signature, return -1
-//n_sig before (smaller) than e_sig signature, return 1
-//at the signature - return 0
-inline int tw_event_sig_compare(tw_event_sig e_sig, tw_event_sig n_sig)
-{
-    int time_compare = TW_STIME_CMP(e_sig.recv_ts, n_sig.recv_ts);
-    if (time_compare != 0)
-        return time_compare;
-    else
-    {
-        if (e_sig.event_tiebreaker < n_sig.event_tiebreaker)
-            return -1;
-        else if (e_sig.event_tiebreaker > n_sig.event_tiebreaker)
-            return 1;
-        else {
-                // tw_error(TW_LOC,"Identical events (matching tiebreaker) found\n");
-                return 0;
-        }
-    }
-}
-#endif
-
 void tw_event_send(tw_event * event) {
     tw_lp     *src_lp = event->src_lp;
     tw_pe     *send_pe = src_lp->pe;

--- a/core/tw-eventq.h
+++ b/core/tw-eventq.h
@@ -109,6 +109,16 @@ tw_eventq_push_list(tw_eventq * q, tw_event * h, tw_event * t, long cnt)
         if (e == h) {
           break;
         }
+
+        // // check for event tie with previous event here (no need to check if prev == NULL as we break from this loop if e is the head of the list)
+        // // event ties should be when timestamp AND destination LP are the same
+        // // because this queue is ordered based on TS, this will find any pairwise event ties
+        // // if three events are tied, then this will result in counting two ties (because there are n-1 pairwise ties in an n-way tie)
+        // if (e->recv_ts == e->prev->recv_ts) {
+        //   if (e->dest_lp->gid == e->prev->dest_lp->gid)
+        //     pe->stats.s_pe_event_ties++;
+        // }
+
         e = e->prev;
     }
 
@@ -118,18 +128,28 @@ tw_eventq_push_list(tw_eventq * q, tw_event * h, tw_event * t, long cnt)
 static inline void
 tw_eventq_fossil_collect(tw_eventq *q, tw_pe *pe)
 {
+#ifndef USE_RAND_TIEBREAKER
   tw_stime gvt = pe->GVT;
-
+#endif
   tw_event *h = q->head;
   tw_event *t = q->tail;
 
   int	 cnt;
 
   /* Nothing to collect from this event list? */
+#ifdef USE_RAND_TIEBREAKER
+  if (!t || (tw_event_sig_compare(t->sig, pe->GVT_sig) >= 0))
+    return;
+#else
   if (!t || (TW_STIME_CMP(t->recv_ts, gvt) >= 0))
     return;
+#endif
 
+#ifdef USE_RAND_TIEBREAKER
+  if (tw_event_sig_compare(h->sig, pe->GVT_sig) < 0)
+#else
   if (TW_STIME_CMP(h->recv_ts, gvt) < 0)
+#endif
     {
       /* Everything in the queue can be collected */
       tw_eventq_push_list(&pe->free_q, h, t, q->size);
@@ -145,7 +165,11 @@ tw_eventq_fossil_collect(tw_eventq *q, tw_pe *pe)
     tw_event *n;
 
     /* Search the leading part of the list... */
+#ifdef USE_RAND_TIEBREAKER
+    for (h = t->prev, cnt = 1; h && (tw_event_sig_compare(h->sig, pe->GVT_sig) < 0); cnt++)
+#else
     for (h = t->prev, cnt = 1; h && (TW_STIME_CMP(h->recv_ts, gvt) < 0); cnt++)
+#endif
       h = h->prev;
 
     /* t isn't eligible for collection; its the new head */

--- a/core/tw-lp.c
+++ b/core/tw-lp.c
@@ -231,7 +231,11 @@ tw_lp_suspend(tw_lp * lp, int do_orig_event_rc, int error_num )
 
   lp->suspend_flag=1;
   lp->suspend_event = lp->pe->cur_event; // only valid prior to GVT
+#ifdef USE_RAND_TIEBREAKER
+  lp->suspend_sig = tw_now_sig(lp);
+#else
   lp->suspend_time = tw_now(lp);
+#endif
   lp->suspend_error_number = error_num;
   lp->suspend_do_orig_event_rc = do_orig_event_rc;
 

--- a/core/tw-pe.c
+++ b/core/tw-pe.c
@@ -41,7 +41,7 @@ tw_pe_init(void)
 	tw_pe_settype(&no_type);
 
 #ifdef USE_RAND_TIEBREAKER
-	g_tw_pe->trans_msg_sig = (tw_event_sig){TW_STIME_MAX,TW_STIME_MAX};
+	g_tw_pe->trans_msg_sig = tw_get_init_sig(TW_STIME_MAX,TW_STIME_MAX);
 #else
 	g_tw_pe->trans_msg_ts = TW_STIME_MAX;
 #endif

--- a/core/tw-pe.c
+++ b/core/tw-pe.c
@@ -40,7 +40,11 @@ tw_pe_init(void)
 	g_tw_pe->id = g_tw_mynode;
 	tw_pe_settype(&no_type);
 
+#ifdef USE_RAND_TIEBREAKER
+	g_tw_pe->trans_msg_sig = (tw_event_sig){TW_STIME_MAX,TW_STIME_MAX};
+#else
 	g_tw_pe->trans_msg_ts = TW_STIME_MAX;
+#endif
 	g_tw_pe->gvt_status = 0;
 
     // TODO is the PE RNG ever actually used?

--- a/core/tw-pe.c
+++ b/core/tw-pe.c
@@ -47,8 +47,8 @@ tw_pe_init(void)
 #endif
 	g_tw_pe->gvt_status = 0;
 
-    // TODO is the PE RNG ever actually used?
 	g_tw_pe->rng = tw_rand_init(31, 41);
+	g_tw_pe->core_rng = tw_rand_core_init(31, 41); // Core RNG must have same v & w values as main RNG
 
 }
 

--- a/core/tw-setup.c
+++ b/core/tw-setup.c
@@ -270,7 +270,7 @@ void tw_define_lps(tw_lpid nlp, size_t msg_sz) {
     // init LP RNG stream(s)
     for(i = 0; i < g_tw_nlp + g_st_analysis_nlp; i++) {
         if(g_tw_rng_default == 1) {
-            tw_rand_init_streams(g_tw_lp[i], g_tw_nRNG_per_lp);
+            tw_rand_init_streams(g_tw_lp[i], g_tw_nRNG_per_lp, g_tw_nRNG_core_per_lp);
         }
     }
 

--- a/core/tw-setup.c
+++ b/core/tw-setup.c
@@ -13,6 +13,11 @@ static tw_pe *setup_pes(void);
 unsigned int nkp_per_pe = 16;
 static tw_clock init_start = 0;
 
+static int32_t ross_rng_seed1;
+static int32_t ross_rng_seed2;
+static int32_t ross_rng_seed3;
+static int32_t ross_rng_seed4;
+
 static const tw_optdef kernel_options[] = {
     TWOPT_GROUP("ROSS Kernel"),
     TWOPT_UINT("synch", g_tw_synchronization_protocol, "Sychronization Protocol: SEQUENTIAL=1, CONSERVATIVE=2, OPTIMISTIC=3, OPTIMISTIC_DEBUG=4, OPTIMISTIC_REALTIME=5"),
@@ -27,6 +32,10 @@ static const tw_optdef kernel_options[] = {
 #ifdef AVL_TREE
     TWOPT_UINT("avl-size", g_tw_avl_node_count, "AVL Tree contains 2^avl-size nodes"),
 #endif
+    TWOPT_UINT("rng-seed1",ross_rng_seed1, "ROSS RNG Seed 1 of 4"),
+    TWOPT_UINT("rng-seed2",ross_rng_seed2, "ROSS RNG Seed 2 of 4"),
+    TWOPT_UINT("rng-seed3",ross_rng_seed3, "ROSS RNG Seed 3 of 4"),
+    TWOPT_UINT("rng-seed4",ross_rng_seed4, "ROSS RNG Seed 4 of 4"),
     TWOPT_END()
 };
 
@@ -110,6 +119,17 @@ void tw_init(int *argc, char ***argv) {
         }
     }
 
+    if(ross_rng_seed1 && ross_rng_seed2 && ross_rng_seed3 && ross_rng_seed4)
+    {
+        printf("%d %d %d %d\n",ross_rng_seed1, ross_rng_seed2, ross_rng_seed3, ross_rng_seed4);
+        g_tw_rng_seed = (int32_t*)calloc(4, sizeof(int32_t));
+        g_tw_rng_seed[0] = ross_rng_seed1;
+        g_tw_rng_seed[1] = ross_rng_seed2;
+        g_tw_rng_seed[2] = ross_rng_seed3;
+        g_tw_rng_seed[3] = ross_rng_seed4;
+    }
+    else if(ross_rng_seed1 || ross_rng_seed2 || ross_rng_seed3 || ross_rng_seed4)
+        tw_error(TW_LOC, "If using --rng-seed#, all four seeds must be specified\n");
     //tw_opt_print();
 
     tw_net_start();

--- a/core/tw-setup.c
+++ b/core/tw-setup.c
@@ -18,6 +18,11 @@ static int32_t ross_rng_seed2;
 static int32_t ross_rng_seed3;
 static int32_t ross_rng_seed4;
 
+static int32_t ross_core_rng_seed1;
+static int32_t ross_core_rng_seed2;
+static int32_t ross_core_rng_seed3;
+static int32_t ross_core_rng_seed4;
+
 static const tw_optdef kernel_options[] = {
     TWOPT_GROUP("ROSS Kernel"),
     TWOPT_UINT("synch", g_tw_synchronization_protocol, "Sychronization Protocol: SEQUENTIAL=1, CONSERVATIVE=2, OPTIMISTIC=3, OPTIMISTIC_DEBUG=4, OPTIMISTIC_REALTIME=5"),
@@ -36,6 +41,10 @@ static const tw_optdef kernel_options[] = {
     TWOPT_UINT("rng-seed2",ross_rng_seed2, "ROSS RNG Seed 2 of 4"),
     TWOPT_UINT("rng-seed3",ross_rng_seed3, "ROSS RNG Seed 3 of 4"),
     TWOPT_UINT("rng-seed4",ross_rng_seed4, "ROSS RNG Seed 4 of 4"),
+    TWOPT_UINT("core-rng-seed1",ross_core_rng_seed1, "ROSS Core RNG Seed 1 of 4"),
+    TWOPT_UINT("core-rng-seed2",ross_core_rng_seed2, "ROSS Core RNG Seed 2 of 4"),
+    TWOPT_UINT("core-rng-seed3",ross_core_rng_seed3, "ROSS Core RNG Seed 3 of 4"),
+    TWOPT_UINT("core-rng-seed4",ross_core_rng_seed4, "ROSS Core RNG Seed 4 of 4"),
     TWOPT_END()
 };
 
@@ -121,7 +130,8 @@ void tw_init(int *argc, char ***argv) {
 
     if(ross_rng_seed1 && ross_rng_seed2 && ross_rng_seed3 && ross_rng_seed4)
     {
-        printf("%d %d %d %d\n",ross_rng_seed1, ross_rng_seed2, ross_rng_seed3, ross_rng_seed4);
+        if (!g_tw_mynode)
+            printf("RNG Seeds: %d %d %d %d\n",ross_rng_seed1, ross_rng_seed2, ross_rng_seed3, ross_rng_seed4);
         g_tw_rng_seed = (int32_t*)calloc(4, sizeof(int32_t));
         g_tw_rng_seed[0] = ross_rng_seed1;
         g_tw_rng_seed[1] = ross_rng_seed2;
@@ -130,6 +140,20 @@ void tw_init(int *argc, char ***argv) {
     }
     else if(ross_rng_seed1 || ross_rng_seed2 || ross_rng_seed3 || ross_rng_seed4)
         tw_error(TW_LOC, "If using --rng-seed#, all four seeds must be specified\n");
+
+    if(ross_core_rng_seed1 && ross_core_rng_seed2 && ross_core_rng_seed3 && ross_core_rng_seed4)
+    {
+        if (!g_tw_mynode)
+            printf("Core RNG Seeds: %d %d %d %d\n",ross_core_rng_seed1, ross_core_rng_seed2, ross_core_rng_seed3, ross_core_rng_seed4);
+        g_tw_core_rng_seed = (int32_t*)calloc(4, sizeof(int32_t));
+        g_tw_core_rng_seed[0] = ross_core_rng_seed1;
+        g_tw_core_rng_seed[1] = ross_core_rng_seed2;
+        g_tw_core_rng_seed[2] = ross_core_rng_seed3;
+        g_tw_core_rng_seed[3] = ross_core_rng_seed4;
+    }
+    else if(ross_core_rng_seed1 || ross_core_rng_seed2 || ross_core_rng_seed3 || ross_core_rng_seed4)
+        tw_error(TW_LOC, "If using --core-rng-seed#, all four seeds must be specified\n");
+
     //tw_opt_print();
 
     tw_net_start();


### PR DESCRIPTION
Re-submitted from PR #180 with better source branch

This is a big PR. Sorry, there's a lot to unpack here.

Starting with the easiest. This PR adds a new array of RNGs to ROSS LPs. These RNG streams are "Core RNGs" and access and usage of them should be reserved exclusively for the ROSS engine itself. Models should not touch these RNG streams at all. Doing so will break any determinism expected by ROSS patterns that utilize them.

Prior to now, obviously, there's nothing in ROSS that would utilize such a stream but also included in this PR is an implementation of an event tie-breaking mechanism which gives ROSS the capability of handling event ties (events that occur on the same LP at the same virtual time) in a deterministic way that is consistent between simulations, regardless of event delivery order.

Deterministic Tie-breaking can be implemented by creating a random value at the creation of an event, this value is encoded into the ROSS event struct and is utilized to break any event ties (same destination LP at same time). Because this separate RNG is only accessed by ROSS, it can be rolled back if the event becomes RC'd or cancelled. Because of
determinism, any ordering as a result of this tiebreaker will be consistent across simulation runs regardless of event delivery order or stragglers. If a regular model-accessed LP RNG was used for this purpose, the tiebreaking sequence would be subject to interference.

The deterministic tiebreaker itself is rather simple. When an event is created, a random value is generated from a ROSS core RNG stream. When that event is RC'd or cancelled, that random value is also
reversed. Because this stream is only utilized by said tiebreaking mechanism, the ordering of tiebreaking values created by the stream is deterministic across simulations. When comparing two events received by an LP at the same timestamp, the determining factor in which is processed first will be decided - deterministically - by the tiebreaker value.

While the concept itself is simple, and implementing the tiebreaker into the event struct is similarly simple, getting this
to work with the concept of GVT and rollbacks is not.

A better way to think about this tiebreaking mechanism is to think of it as making sure that there are actually no such thing as event ties. This paradigm shift means that determining "when" GVT happens is no longer a single TW_STIME value. There is now an event signature struct which contains a timestamp and a tiebreaker value. This signature is all that is necessary for determining ordering of two events in the simulation. Thus, the time of the last GVT is no longer just the single dimensional virtual timestamp, but it also includes a tiebreaker which divides events that happen at the same primary timestamp as GVT but with their own tiebreaker values which will be deterministically separated as "before GVT" and "after GVT".

Thus, rollbacks now also no longer go back to a single timestamp value in time, but to a two dimensional timestamp value consisting of the primary timestamp and an event tiebreaker.

As complex as this system is, it does have its benefits:

1) Comparing events for Splay and AVL trees to determine ordering require fewer comparisons and thus less compute time spent.
2) If primary timestamp ties are numerous in a model, rolling back of one event at said timestamp will no longer require rolling back all events with the same timestamp, only those whose tiebreaker values
determine that they happen "after" the event that prompted the rollback.
3) Event ties are statistically impossible to force. Because the tiebreaker value is generated using its own independent RNG stream with an extremely long period, two events at the same primary timestamp ALSO generating an identical random value is nearly impossible. This also means that model developers will no longer have to generate their own small noise to add onto their event timestamps to prevent event ties, significantly improving the administrative code complexity - reducing the likelihood that a developer will forget to roll back an RNG from noise and plunge their entire model into non-determinism.

This feature has been walled off behind a CMAKE Define Variable: USE_RAND_TIEBREAKER. Set this value to ON during CMAKE ROSS configuration and all code enabling the tiebreaking value generation and the timestamp-to-time-signature paradigm shift will be switched on by pre-processor #ifdef's.

Ultimately, it may be beneficial to make this event time signature the actual primary mechanism by which the ROSS engine operates but I didn't want to make said major change in this PR. There is probably a cleaner way to implement it as well (possibly using the TW_STIME API?)

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [website Contributing guide](https://github.com/ROSS-org/ross-org.github.io/blob/master/CONTRIBUTING.md)).
  Include a link to your blog post in the Pull Request.
- [ ] Builds should cleanly compile with -Wall and -Wextra.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
