### PR TITLE
ross-types.h fixed compiler warnings about the code

### DIFF
--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -273,7 +273,7 @@ static inline tw_event_sig tw_get_init_sig(tw_stime recv_ts, tw_stime event_tieb
     tw_event_sig e;
     memset(&e, 0, sizeof(tw_event_sig));
     e.recv_ts = recv_ts;
-    memset(e.event_tiebreaker, event_tiebreaker, MAX_TIE_CHAIN);
+    memset(e.event_tiebreaker, event_tiebreaker, sizeof(tw_stime)*MAX_TIE_CHAIN);
     // e.event_tiebreaker = event_tiebreaker;
     return e;
 }
@@ -504,10 +504,10 @@ static inline int tw_event_sig_compare(tw_event_sig e_sig, tw_event_sig n_sig)
         return time_compare;
     else {
         int min_len = min_int(e_sig.tie_lineage_length, n_sig.tie_lineage_length);
-        int j = 0;
+        //int j = 0;
         for(int i = 0; i < min_len; i++) //lexicographical ordering
         {
-            j = i;
+            //j = i;
             if (e_sig.event_tiebreaker[i] < n_sig.event_tiebreaker[i])
                 return -1;
             else if (e_sig.event_tiebreaker[i] > n_sig.event_tiebreaker[i])


### PR DESCRIPTION
static inline tw_event_sig tw_get_init_sig(tw_stime, tw_stime): added a sizeof() multiplier for memset

static inline int tw_event_sig_compare(tw_event_sig e_sig, tw_event_sig n_sig): removed an unused int

**add your comments here**

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [website Contributing guide](https://github.com/ROSS-org/ross-org.github.io/blob/master/CONTRIBUTING.md)).
  Include a link to your blog post in the Pull Request.
- [ ] Builds should cleanly compile with -Wall and -Wextra.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
