### PR TITLE
Add option for command line config file

### DIFF
--- a/core/tw-opts.h
+++ b/core/tw-opts.h
@@ -11,6 +11,7 @@ enum tw_opttype
         TWOPTTYPE_DOUBLE,      /**< value must be a  "double *"            */
 	TWOPTTYPE_CHAR,        /**< value must be a  "char *"              */
         TWOPTTYPE_FLAG,        /**< value must be an "unsigned int*"       */
+	TWOPTTYPE_ARGSFILE,    /**< value must be a  "char *"              */
 	TWOPTTYPE_SHOWHELP
 };
 typedef enum tw_opttype tw_opttype;
@@ -31,11 +32,13 @@ struct tw_optdef
 #define TWOPT_STIME(n,v,h)     { TWOPTTYPE_STIME,     (n), (h), &(v) }
 #define TWOPT_DOUBLE(n,v,h)    { TWOPTTYPE_DOUBLE,    (n), (h), &(v) }
 #define TWOPT_CHAR(n,v,h)      { TWOPTTYPE_CHAR,      (n), (h), &(v) }
+#define TWOPT_ARGSFILE(n,v,h)  { TWOPTTYPE_ARGSFILE,(n), (h), &(v) }
 #define TWOPT_FLAG(n,v,h)      { TWOPTTYPE_FLAG,      (n), (h), &(v) }
 #define TWOPT_END()            { (tw_opttype)0,     NULL, NULL, NULL }
 
 /** Remove options from the command line arguments. */
 extern void tw_opt_parse(int *argc, char ***argv);
+extern void tw_opt_parse_args_file(char *file_name, int *argc, char ***argv);
 /** Add an opt group */
 extern void tw_opt_add(const tw_optdef *options);
 /** Pretty-print the option descriptions (for --help) */

--- a/core/tw-setup.c
+++ b/core/tw-setup.c
@@ -22,6 +22,7 @@ static int32_t ross_core_rng_seed1;
 static int32_t ross_core_rng_seed2;
 static int32_t ross_core_rng_seed3;
 static int32_t ross_core_rng_seed4;
+static char* ross_args_file;
 
 static const tw_optdef kernel_options[] = {
     TWOPT_GROUP("ROSS Kernel"),
@@ -45,6 +46,7 @@ static const tw_optdef kernel_options[] = {
     TWOPT_UINT("core-rng-seed2",ross_core_rng_seed2, "ROSS Core RNG Seed 2 of 4"),
     TWOPT_UINT("core-rng-seed3",ross_core_rng_seed3, "ROSS Core RNG Seed 3 of 4"),
     TWOPT_UINT("core-rng-seed4",ross_core_rng_seed4, "ROSS Core RNG Seed 4 of 4"),
+    TWOPT_ARGSFILE("args-file",ross_args_file, "ROSS Command Line Args File"),
     TWOPT_END()
 };
 


### PR DESCRIPTION
This commit adds an option of passing arguments to ROSS via the command line to a .txt config file containing the same command line arguments.