### PR TITLE
Add instructions for args-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,20 @@ See [this blog post](https://ross-org.github.io/setup/running-sim.html) for deta
   ./your-model --synch=1               // sequential mode
   mpirun -np 2 ./your-model --synch=2  // conservative mode
   mpirun -np 2 ./your-model --synch=3  // optimistic mode
+  ```
+You can pass arguments to your model from the command line as shown below.
+  ``` 
   ./your-model --synch=4               // optimistic debug mode (note: not a parallel execution!)
+  ```
+However, for better readability, it is also possible to pass command line arguments through a text file.
+A sample text file sample.txt is included below.
+  ```
+  # Synchonization protocol
+  --synch=4
+  # AVL Tree contains 2^avl-size nodes (default 18)
+  --avl-size=18
+  ```
+The text file is then parsed by ROSS through the args-file command line argument.
+  ```
+  ./your-model --args-file=sample.txt
   ```


### PR DESCRIPTION
This commit adds instructions to use the args-file command line argument.

**add your comments here**

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [website Contributing guide](https://github.com/ROSS-org/ross-org.github.io/blob/master/CONTRIBUTING.md)).
  Include a link to your blog post in the Pull Request.
- [ ] Builds should cleanly compile with -Wall and -Wextra.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
