### PR TITLE
Fixing GVT hook trigger when called by LPs

### DIFF
--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -539,8 +539,12 @@ void tw_trigger_gvt_hook_now(tw_lp * lp) {
     if (g_tw_gvt_hook_trigger.status != GVT_HOOK_STATUS_model_call) {
         tw_error(TW_LOC, "`tw_trigger_gvt_hook_now` called but `g_tw_gvt_hook_trigger.status != GVT_HOOK_STATUS_model_call`. Either `tw_trigger_gvt_hook_when_model_calls` was not called or another trigger function has been");
     }
+    if (g_tw_gvt_hook_trigger.sig_at.tie_lineage_length >= MAX_TIE_CHAIN) {
+      tw_error(TW_LOC, "Maximum zero-offset tie chain reached (%d), increase #define in ross-types.h", MAX_TIE_CHAIN);
+    }
     tw_event_sig * now = &lp->kp->last_sig; // tw_now_sig(lp);
     tw_copy_event_sig(&g_tw_gvt_hook_trigger.sig_at, now);
+    // We store as the trigger time the next valid, larger tiebreaker signature. It is unlikely we will this will tie with any other signature
     g_tw_gvt_hook_trigger.sig_at.event_tiebreaker[g_tw_gvt_hook_trigger.sig_at.tie_lineage_length] = 0;
     g_tw_gvt_hook_trigger.sig_at.tie_lineage_length += 1;
 

--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -211,7 +211,7 @@ tw_gvt_step2(tw_pe *me)
 	tw_copy_event_sig(&pq_min_sig, tw_pq_minimum_sig_ptr(me->pq));
 	tw_copy_event_sig(&net_min_sig, tw_net_minimum_sig_ptr());
 
-	lvt_sig = me->trans_msg_sig;
+	tw_copy_event_sig(&lvt_sig, &me->trans_msg_sig);
 	if(tw_event_sig_compare_ptr(&lvt_sig, &pq_min_sig) > 0)
 	{
 		tw_copy_event_sig(&lvt_sig, &pq_min_sig);
@@ -219,6 +219,12 @@ tw_gvt_step2(tw_pe *me)
 	if(tw_event_sig_compare_ptr(&lvt_sig, &net_min_sig) > 0)
 	{
 		tw_copy_event_sig(&lvt_sig, &net_min_sig);
+	}
+	if(g_tw_gvt_hook
+        && g_tw_gvt_hook_trigger.status
+        && tw_event_sig_compare_ptr(&lvt_sig, &g_tw_gvt_hook_trigger.sig_at) > 0)
+	{
+		tw_copy_event_sig(&lvt_sig, &g_tw_gvt_hook_trigger.sig_at);
 	}
 
 	all_reduce_cnt++;
@@ -517,6 +523,7 @@ void tw_trigger_gvt_hook_every(int num_gvt_calls) {
     g_tw_gvt_hook_trigger.status = GVT_HOOK_STATUS_every_n_gvt;
     g_tw_gvt_hook_trigger.every_n_gvt.starting_at = g_tw_gvt_done;
     g_tw_gvt_hook_trigger.every_n_gvt.nums = num_gvt_calls;
+    tw_copy_event_sig(&g_tw_gvt_hook_trigger.sig_at, &g_tw_max_sig);
 }
 
 void tw_trigger_gvt_hook_when_model_calls(void) {
@@ -534,6 +541,8 @@ void tw_trigger_gvt_hook_now(tw_lp * lp) {
     }
     tw_event_sig * now = &lp->kp->last_sig; // tw_now_sig(lp);
     tw_copy_event_sig(&g_tw_gvt_hook_trigger.sig_at, now);
+    g_tw_gvt_hook_trigger.sig_at.event_tiebreaker[g_tw_gvt_hook_trigger.sig_at.tie_lineage_length] = 0;
+    g_tw_gvt_hook_trigger.sig_at.tie_lineage_length += 1;
 
     // Forcing GVT to happen now (possibly triggering gvt hook)
     lp->pe->gvt_status = TW_GVT_COMPUTE;  // same behavior as if calling `tw_gvt_force_update()`

--- a/core/ross-gvt-internal.h
+++ b/core/ross-gvt-internal.h
@@ -83,21 +83,19 @@ enum GVT_HOOK_STATUS {
 // Holds one timestamp at which to trigger the arbitrary function
 struct gvt_hook_trigger {
     enum GVT_HOOK_STATUS status;
-    union {
-        // GVT_HOOK_TYPE_timestamp and GVT_HOOK_STATUS_model_call
-        struct {
+    // GVT_HOOK_TYPE_timestamp and GVT_HOOK_STATUS_model_call
+    struct {
 #ifdef USE_RAND_TIEBREAKER
-        tw_event_sig sig_at;
+    tw_event_sig sig_at;
 #else
-        tw_stime at;
+    tw_stime at;
 #endif
-        };
-        // GVT_HOOK_TYPE_every_n_gvt
-        struct {
-            int starting_at;
-            int nums;
-        } every_n_gvt;
     };
+    // GVT_HOOK_TYPE_every_n_gvt
+    struct {
+        int starting_at;
+        int nums;
+    } every_n_gvt;
 };
 
 extern struct gvt_hook_trigger g_tw_gvt_hook_trigger;

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -601,7 +601,7 @@ static inline void tw_gvt_hook_step(tw_pe * me) {
             }
             break;
             case GVT_HOOK_STATUS_model_call: {
-                bool const triggered_here = tw_event_sig_compare_ptr(&me->GVT_sig, &g_tw_gvt_hook_trigger.sig_at) > 0;
+                bool const triggered_here = tw_event_sig_compare_ptr(&me->GVT_sig, &g_tw_gvt_hook_trigger.sig_at) >= 0;
                 bool const triggered_somewhere = does_any_pe(triggered_here);
                 if (triggered_somewhere) {
                    // LP has triggered GVT hook


### PR DESCRIPTION
Bug: if two LPs in different PEs trigger the GVT hook independently at the same GVT, only the first on virtual time should count as the ONE that "triggered" GVT (taking into account the tiebreaker)